### PR TITLE
Adds a note about using custom keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ handle: React.PropTypes.string,
 
 // Layout is an array of object with the format:
 // {x: Number, y: Number, w: Number, h: Number}
+// The index into the layout must match the key used on each item component.
+// If you choose to use custom keys, you can specify that key in the layout
+// array objects like so:
+// {i: String, x: Number, y: Number, w: Number, h: Number}
 layout: React.PropTypes.array,
 
 // This allows setting this on the server side


### PR DESCRIPTION
If you do not use the index for a grid item key, then the layout cannot be found.  You can explicitly set the layout id using an object property named `i`.

I think this would be valuable to add to the documentation.  Not sure if this is the best place for the info though.