### PR TITLE
updating verticalCompact documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ draggableCancel: React.PropTypes.string,
 draggableHandle: React.PropTypes.string,
 
 // If true, the layout will compact vertically
-draggableHandle: React.PropTypes.string,
+verticalCompact: React.PropTypes.bool,
 
 // Layout is an array of object with the format:
 // {x: Number, y: Number, w: Number, h: Number}


### PR DESCRIPTION
The documentation for `verticalCompact` is incorrect. `draggableHandle` is listed twice instead.