### PR TITLE
Implementing scrollableParent property and propagating it to draggables

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -205,6 +205,7 @@ var GridItem = React.createClass({
         handle={this.props.handle}
         cancel={".react-resizable-handle " + this.props.cancel}
         useCSSTransforms={this.props.useCSSTransforms}
+        scrollableAncestor={this.props.scrollableAncestor}
         >
         {child}
       </Draggable>

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -116,7 +116,8 @@ var ReactGridLayout = React.createClass({
       onDragStop: function() {},
       onResizeStart: function() {},
       onResize: function() {},
-      onResizeStop: function() {}
+      onResizeStop: function() {},
+      scrollableAncestor: document
     };
   },
 
@@ -325,6 +326,7 @@ var ReactGridLayout = React.createClass({
         isDraggable={false}
         isResizable={false}
         useCSSTransforms={this.props.useCSSTransforms}
+        scrollableAncestor={this.props.scrollableAncestor}
         >
         <div />
       </GridItem>
@@ -369,6 +371,7 @@ var ReactGridLayout = React.createClass({
         isResizable={resizable}
         useCSSTransforms={this.props.useCSSTransforms && this.state.isMounted}
         usePercentages={!this.state.isMounted}
+        scrollableAncestor={this.props.scrollableAncestor}
         {...l}
         >
         {child}


### PR DESCRIPTION
Hi,

This is related to following pull request for react-draggable: https://github.com/mzabriskie/react-draggable/pull/86

It solves the issue of draggables being inside the scrollable container which is not document.body.

https://www.youtube.com/watch?v=FZ-L5x4E02k

Cheers,

Danko