### PR TITLE
use requestAnimationFrame to detect any change in width

### DIFF
--- a/lib/mixins/WidthListeningMixin.js
+++ b/lib/mixins/WidthListeningMixin.js
@@ -24,7 +24,11 @@ var WidthListeningMixin = {
 
   componentDidMount: function() {
     if (this.props.listenToWindowResize) {
-      window.addEventListener('resize', this.onWindowResize);
+      if (window.requestAnimationFrame) {
+        this.killListener = widthListener(this.getDOMNode(), this.onWidthChange);
+      } else {
+        window.addEventListener('resize', this.onWindowResize);
+      }
       // This is intentional. Once to properly set the breakpoint and resize the elements,
       // and again to compensate for any scrollbar that appeared because of the first step.
       this.onWindowResize();
@@ -32,8 +36,12 @@ var WidthListeningMixin = {
     }
   },
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.onWindowResize);
+  componentWillUnmount: function() {
+    if (this.killListener) {
+      this.killListener();
+    } else {
+      window.removeEventListener('resize', this.onWindowResize);
+    }
   },
 
   /**
@@ -46,3 +54,33 @@ var WidthListeningMixin = {
 };
 
 module.exports = WidthListeningMixin;
+
+
+function widthListener(domNode, callback) {
+
+  function getWidth() {
+    return domNode.offsetWidth;
+  }
+
+  var stillListening = true,
+      widthNow = getWidth();
+
+  function watch() {
+    if (!stillListening) return;
+
+    var nextWidth = getWidth();
+
+    if (nextWidth !== widthNow) {
+      callback(nextWidth);
+      widthNow = nextWidth;
+    }
+
+    // and loop again
+    requestAnimationFrame(watch);
+  }
+
+  // start loop
+  requestAnimationFrame(watch);
+
+  return function kill() { stillListening = false; };
+}


### PR DESCRIPTION
I just started using this strategy with some dynamic canvas containers to get 60FPS smooth resize, whether triggered by the window, or some other UI change.

In practice, I find it seems to be as performant as `window.on('resize', ...)`, but I haven't done any scientific tests. In theory, it makes sense it would work as well or better, because of the [point in the event loop at which `requestAnimationFrame` executes](http://www.html5rocks.com/en/tutorials/speed/animations/).

To test, try changing the `width` of the `#content` div to some explicit value, and watch the magic.

Note: I left the `resize` stuff there in case you want to [support <=IE9](http://caniuse.com/#feat=requestanimationframe). Could also use a polyfill, but I think perf may go down the tubes with `setInterval`.

Also: this solves the problem that prompted #104 for me. The pedantic purist in me would still rather have percentages all the way down, but this is a much lower-impact change that achieves roughly the same result.
