### PR TITLE
Add missing React import

### DIFF
--- a/lib/components/ListensToWidth.jsx
+++ b/lib/components/ListensToWidth.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { PropTypes, Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 import ReactDOM from 'react-dom';
 
 type Props = {initialWidth: number, listenToWindowResize: boolean};


### PR DESCRIPTION
When using this branch, I got a `React is undefined` error. Adding `React` as an import fixed this issue.