### PR TITLE
changed LayoutItem.i property to be of type "string" instead of "number"

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -47,7 +47,7 @@ export default class GridItem extends Component {
     },
 
     // ID is nice to have for callbacks
-    i: React.PropTypes.number.isRequired,
+    i: React.PropTypes.string.isRequired,
 
     // If true, item will be repositioned when x/y/w/h change
     moveOnStartChange: React.PropTypes.bool,

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -194,14 +194,14 @@ class ReactGridLayout extends React.Component {
 
   /**
    * When dragging starts
-   * @param {Number} i Index of the child
+   * @param {String} i Id of the child
    * @param {Number} x X position of the move
    * @param {Number} y Y position of the move
    * @param {Event} e The mousedown event
    * @param {Element} element The current dragging DOM element
    * @param {Object} position Drag information
    */
-  onDragStart = (i: number, x: number, y: number, {e, element}: DragEvent) => {
+  onDragStart = (i: string, x: number, y: number, {e, element}: DragEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     if (!l) return;
@@ -212,14 +212,14 @@ class ReactGridLayout extends React.Component {
   };
   /**
    * Each drag movement create a new dragelement and move the element to the dragged location
-   * @param {Number} i Index of the child
+   * @param {String} i Id of the child
    * @param {Number} x X position of the move
    * @param {Number} y Y position of the move
    * @param {Event} e The mousedown event
    * @param {Element} element The current dragging DOM element
    * @param {Object} position Drag information
    */
-  onDrag = (i: number, x: number, y: number, {e, element}: DragEvent) => {
+  onDrag = (i: string, x: number, y: number, {e, element}: DragEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     if (!l) return;
@@ -244,7 +244,7 @@ class ReactGridLayout extends React.Component {
 
   /**
    * When dragging stops, figure out which position the element is closest to and update its x and y.
-   * @param  {Number} i Index of the child.
+   * @param  {String} i Index of the child.
    * @param {Number} i Index of the child
    * @param {Number} x X position of the move
    * @param {Number} y Y position of the move
@@ -252,7 +252,7 @@ class ReactGridLayout extends React.Component {
    * @param {Element} element The current dragging DOM element
    * @param {Object} position Drag information
    */
-  onDragStop = (i: number, x: number, y: number, {e, element}: DragEvent) => {
+  onDragStop = (i: string, x: number, y: number, {e, element}: DragEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     if (!l) return;
@@ -271,7 +271,7 @@ class ReactGridLayout extends React.Component {
     });
   };
 
-  onResizeStart = (i: number, w: number, h: number, {e, element}: ResizeEvent) => {
+  onResizeStart = (i: string, w: number, h: number, {e, element}: ResizeEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     if (!l) return;
@@ -281,7 +281,7 @@ class ReactGridLayout extends React.Component {
     this.props.onResizeStart(layout, l, l, null, e, element);
   };
 
-  onResize = (i: number, w: number, h: number, {e, element}: ResizeEvent) => {
+  onResize = (i: string, w: number, h: number, {e, element}: ResizeEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     if (!l) return;
@@ -302,7 +302,7 @@ class ReactGridLayout extends React.Component {
     this.setState({ layout: compact(layout, this.props.verticalCompact), activeDrag: placeholder });
   };
 
-  onResizeStop = (i: number, w: number, h: number, {e, element}: ResizeEvent) => {
+  onResizeStop = (i: string, w: number, h: number, {e, element}: ResizeEvent) => {
     var layout = this.state.layout;
     var l = getLayoutItem(layout, i);
     var oldL = this.state.oldResizeItem;
@@ -349,12 +349,12 @@ class ReactGridLayout extends React.Component {
   /**
    * Given a grid item, set its style attributes & surround in a <Draggable>.
    * @param  {Element} child React element.
-   * @param  {Number}  i     Index of element.
+   * @param  {string}  i     Index of element.
    * @return {Element}       Element wrapped in draggable and properly placed.
    */
   processGridItem(child: ReactElement): ?ReactElement {
     if (!child.key) return;
-    var i = parseInt(child.key, 10);
+    var i = child.key;
     var l = getLayoutItem(this.state.layout, i);
     if (!l) return;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 import assign from 'object-assign';
 
 /*global ReactElement*/
-export type LayoutItem = {w: number, h: number, x: number, y: number, i: number, placeholder?: boolean, moved?: boolean};
+export type LayoutItem = {w: number, h: number, x: number, y: number, i: string, placeholder?: boolean, moved?: boolean};
 export type Layout = Array<LayoutItem>;
 export type Position = {left: number, top: number, width: number, height: number};
 export type Size = {width: number, height: number};
@@ -138,10 +138,10 @@ export function correctBounds(layout: Layout, bounds: {cols: number}): Layout {
  * Get a layout item by ID. Used so we can override later on if necessary.
  *
  * @param  {Array}  layout Layout array.
- * @param  {Number} id     ID
+ * @param  {String} id     ID
  * @return {LayoutItem}    Item at ID.
  */
-export function getLayoutItem(layout: Layout, id: number): ?LayoutItem {
+export function getLayoutItem(layout: Layout, id: string): ?LayoutItem {
   for (let i = 0, len = layout.length; i < len; i++) {
     if (layout[i].i === id) return layout[i];
   }
@@ -330,7 +330,7 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
   for (let i = 0, len = children.length; i < len; i++) {
     let child = children[i];
     // Don't overwrite if it already exists.
-    let exists = getLayoutItem(initialLayout, parseInt(child.key || "1" /* FIXME satisfies Flow */, 10));
+    let exists = getLayoutItem(initialLayout, child.key || "1" /* FIXME satisfies Flow */);
     if (exists) {
       layout.push(exists);
       continue;
@@ -342,13 +342,13 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
       // Validated; add it to the layout. Bottom 'y' possible is the bottom of the layout.
       // This allows you to do nice stuff like specify {y: Infinity}
       if (verticalCompact) {
-        layout.push(assign({}, g, {y: Math.min(bottom(layout), g.y), i: parseInt(child.key)}));
+        layout.push(assign({}, g, {y: Math.min(bottom(layout), g.y), i: child.key}));
       } else {
-        layout.push(assign({}, g, {y: g.y, i: parseInt(child.key)}));
+        layout.push(assign({}, g, {y: g.y, i: child.key}));
       }
     } else {
       // Nothing provided: ensure this is added to the bottom
-      layout.push({w: 1, h: 1, x: 0, y: bottom(layout), i: parseInt(child.key || "1", 10)});
+      layout.push({w: 1, h: 1, x: 0, y: bottom(layout), i: child.key || "1"});
     }
   }
 


### PR DESCRIPTION
Not sure if you'll want this one or not. For the project within which I'm using react-grid-layout, I use strings (GUIDs) as the type for layout item ids, i.e. **LayoutItem.i**. Unfortunately, converting to integers isn't an option (for me at least), so it would be nice to retain the flexibility of using a string as the layout item key/id. 

I suspect there was likely a good reason behind converting to integer, but I'm hoping the use of strings won't be too abrasive.

cheers!

