### PR TITLE
enable passing className property to <GridItem/>

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -369,6 +369,7 @@ class ReactGridLayout extends React.Component {
 
     return (
       <GridItem
+        className={child.props.className}
         containerWidth={this.state.width}
         cols={this.props.cols}
         margin={this.props.margin}


### PR DESCRIPTION
I want to be able to set a `className` property on the `<GridItem />`

It does seem to have `className` listed as an optional `propType`