### PR TITLE
updated docs; fixed examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 0.10.0
 ------
+> Breaking changes: `ListensToWidth` replaced with `WidthProvider` which must wrap 
+`<ResponsiveReactGridLayout>` and `<ReactGridLayout>` to provide width and offset data. See doc for example.
+
+> Breaking changes: Prop `initialWidth` renamed to `width`.
+> Grid Layout keys must be type of string now.
 
 - *Finally* compatible with React 0.14! Big thanks to @menelike for his help.
 - Upgraded to Babel 6.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ var ReactGridLayout = require('react-grid-layout');
 render: function() {
   return (
     <ReactGridLayout className="layout" cols={12} rowHeight={30}>
-      <div key={1} _grid={{x: 0, y: 0, w: 1, h: 2}}>1</div>
-      <div key={2} _grid={{x: 1, y: 0, w: 1, h: 2}}>2</div>
-      <div key={3} _grid={{x: 2, y: 0, w: 1, h: 2}}>3</div>
+      <div key={"1"} _grid={{x: 0, y: 0, w: 1, h: 2}}>1</div>
+      <div key={"2"} _grid={{x: 1, y: 0, w: 1, h: 2}}>2</div>
+      <div key={"3"} _grid={{x: 2, y: 0, w: 1, h: 2}}>3</div>
     </ReactGridLayout>
   )
 }
@@ -120,9 +120,9 @@ render: function() {
     <ResponsiveReactGridLayout className="layout" layouts={layouts}
       breakpoints={{lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0}}
       cols={{lg: 12, md: 10, sm: 6, xs: 4, xxs: 2}}>
-      <div key={1}>1</div>
-      <div key={2}>2</div>
-      <div key={3}>3</div>
+      <div key={"1"}>1</div>
+      <div key={"2"}>2</div>
+      <div key={"3"}>3</div>
     </ResponsiveReactGridLayout>
   )
 }
@@ -135,6 +135,34 @@ If the largest is provided, RGL will attempt to interpolate the rest.
 
 For the time being, it is not possible to supply responsive mappings via the `_grid` property on individual
 items, but that is coming soon.
+
+#### Providing grid width and offsets
+Both `<ResponsiveReactGridLayout>` and `<ReactGridLayout>` take `width`, `offsetX` and `offsetY` to calculate 
+positions on drag events. In simple cases a HOC `<WidthProvider>` can be used to automatically determine 
+all values upon initialization and window resize events.
+  
+```javascript
+var WidthProvider = require('react-grid-layout').WidthProvider;
+var ResponsiveReactGridLayout = require('react-grid-layout').Responsive;
+ResponsiveReactGridLayout = WidthProvider(ResponsiveReactGridLayout);
+
+//...
+render: function() {
+  // {lg: layout1, md: layout2, ...}
+  var layouts = getLayoutsFromSomewhere();
+  return (
+    <ResponsiveReactGridLayout className="layout" layouts={layouts}
+      breakpoints={{lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0}}
+      cols={{lg: 12, md: 10, sm: 6, xs: 4, xxs: 2}}>
+      <div key={"1"}>1</div>
+      <div key={"2"}>2</div>
+      <div key={"3"}>3</div>
+    </ResponsiveReactGridLayout>
+  )
+}
+```
+  
+This allows you to easily replace `<WidthProvider>` with your own Provider HOC if you need a more sophisticated logic.
 
 #### Compatibility
 
@@ -175,7 +203,13 @@ verticalCompact: React.PropTypes.bool,
 layout: React.PropTypes.array,
 
 // This allows setting the initial width on the server side.
-initialWidth: React.PropTypes.number,
+width: React.PropTypes.number.isRequired,
+
+// This sets the correct drag positions on the x axis.
+offsetX: React.PropTypes.number.isRequired,
+
+// This sets the correct drag positions on the y axis.
+offsetY: React.PropTypes.number.isRequired,
 
 // Margin between items [x, y] in px.
 margin: React.PropTypes.array,
@@ -311,7 +345,6 @@ will be draggable.
   breakpoints: {lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0},
   cols: 10,
   rowHeight: 150,
-  initialWidth: 1280,
   margin: [10, 10],
   minH: 1,
   minW: 1,

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -49,7 +49,7 @@ export default class ReactGridLayout extends React.Component {
     verticalCompact: React.PropTypes.bool,
 
     // layout is an array of object with the format:
-    // {x: Number, y: Number, w: Number, h: Number, i: Number}
+    // {x: Number, y: Number, w: Number, h: Number, i: String}
     layout: function (props) {
       var layout = props.layout;
       // I hope you're setting the _grid property on the grid items

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -250,10 +250,18 @@ export default class ReactGridLayout extends React.Component {
 
     // Set state
     this.setState({
-      layout: compact(layout, this.props.verticalCompact),
       activeDrag: null,
       oldDragItem: null
     });
+
+    // Set State and callback, but only if layout changed
+    const newLayout = compact(layout, this.props.verticalCompact);
+    if (!isEqual(newLayout, this.state.layout)) {
+      this.setState({
+        layout: newLayout
+      });
+      this.props.onLayoutChange(this.state.layout);
+    }
   }
 
   onResizeStart(i:string, w:number, h:number, {e, node}: ResizeEvent) {
@@ -292,11 +300,20 @@ export default class ReactGridLayout extends React.Component {
 
     this.props.onResizeStop(layout, oldResizeItem, l, null, e, node);
 
+    // Set state
     this.setState({
-      layout: compact(layout, this.props.verticalCompact),
       activeDrag: null,
       oldResizeItem: null
     });
+
+    // Set State and callback, but only if layout changed
+    const newLayout = compact(layout, this.props.verticalCompact);
+    if (!isEqual(newLayout, this.state.layout)) {
+      this.setState({
+        layout: newLayout
+      });
+      this.props.onLayoutChange(this.state.layout);
+    }
   }
 
 

--- a/test/examples/1-basic.jsx
+++ b/test/examples/1-basic.jsx
@@ -2,7 +2,10 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
+
 
 var BasicLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -37,7 +40,7 @@ var BasicLayout = React.createClass({
     var p = this.props;
     return _.map(new Array(p.items), function(item, i) {
       var y = _.result(p, 'y') || Math.ceil(Math.random() * 4) + 1;
-      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i};
+      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i.toString()};
     });
   },
 

--- a/test/examples/10-dynamic-min-max-wh.jsx
+++ b/test/examples/10-dynamic-min-max-wh.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 /**
  * This layout demonstrates how to use the `onResize` handler to enforce a min/max width and height.
@@ -45,7 +47,7 @@ var DynamicMinMaxLayout = React.createClass({
       var w = _.random(1, 2);
       var h = _.random(1, 3);
       return {
-        x: i * 2 % 12, y: Math.floor(i / 6), w: w, h: h, i: i
+        x: i * 2 % 12, y: Math.floor(i / 6), w: w, h: h, i: i.toString()
       };
     });
   },

--- a/test/examples/11-no-vertical-compact.jsx
+++ b/test/examples/11-no-vertical-compact.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 var NoCompactingLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -39,7 +41,7 @@ var NoCompactingLayout = React.createClass({
     var p = this.props;
     return _.map(new Array(p.items), function(item, i) {
       var y = _.result(p, 'y') || Math.ceil(Math.random() * 4) + 1;
-      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i};
+      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i.toString()};
     });
   },
 

--- a/test/examples/2-no-dragging.jsx
+++ b/test/examples/2-no-dragging.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 var NoDraggingLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -39,7 +41,7 @@ var NoDraggingLayout = React.createClass({
     var p = this.props;
     return _.map(new Array(p.items), function(item, i) {
       var y = _.result(p, 'y') || Math.ceil(Math.random() * 4) + 1;
-      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i};
+      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: 2, h: y, i: i.toString()};
     });
   },
 

--- a/test/examples/3-messy.jsx
+++ b/test/examples/3-messy.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 var MessyLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -38,7 +40,7 @@ var MessyLayout = React.createClass({
     return _.map(new Array(p.items), function(item, i) {
       var w = Math.ceil(Math.random() * 4);
       var y = Math.ceil(Math.random() * 4) + 1;
-      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i};
+      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i.toString()};
     });
   },
 

--- a/test/examples/4-grid-property.jsx
+++ b/test/examples/4-grid-property.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 var GridPropertyLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -35,7 +37,7 @@ var GridPropertyLayout = React.createClass({
     return _.map(new Array(p.items), function(item, i) {
       var w = _.result(p, 'w') || Math.ceil(Math.random() * 4);
       var y = _.result(p, 'y') || Math.ceil(Math.random() * 4) + 1;
-      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i};
+      return {x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i.toString()};
     });
   },
 

--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -1,7 +1,9 @@
 'use strict';
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 /**
  * This layout demonstrates how to use static grid elements.
@@ -21,9 +23,9 @@ var StaticElementsLayout = React.createClass({
   render() {
     return (
       <ReactGridLayout className="layout" onLayoutChange={this.onLayoutChange} rowHeight={30}>
-        <div key={1} _grid={{x: 0, y: 0, w: 2, h: 3}}><span className="text">1</span></div>
-        <div key={2} _grid={{x: 2, y: 0, w: 4, h: 3, static: true}}><span className="text">2 - Static</span></div>
-        <div key={3} _grid={{x: 6, y: 0, w: 2, h: 3}}><span className="text">3</span></div>
+        <div key={"1"} _grid={{x: 0, y: 0, w: 2, h: 3}}><span className="text">1</span></div>
+        <div key={"2"} _grid={{x: 2, y: 0, w: 4, h: 3, static: true}}><span className="text">2 - Static</span></div>
+        <div key={"3"} _grid={{x: 6, y: 0, w: 2, h: 3}}><span className="text">3</span></div>
       </ReactGridLayout>
     );
   }

--- a/test/examples/6-dynamic-add-remove.jsx
+++ b/test/examples/6-dynamic-add-remove.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ResponsiveReactGridLayout = require('react-grid-layout').Responsive;
+ResponsiveReactGridLayout = WidthProvider(ResponsiveReactGridLayout);
 
 /**
  * This layout demonstrates how to use a grid with a dynamic number of elements.
@@ -21,7 +23,7 @@ var AddRemoveLayout = React.createClass({
   getInitialState() {
     return {
       items: [0, 1, 2, 3, 4].map(function(i, key, list) {
-        return {i: i, x: i * 2, y: 0, w: 2, h: 2, add: i === list.length - 1};
+        return {i: i.toString(), x: i * 2, y: 0, w: 2, h: 2, add: i === (list.length - 1).toString()};
       }),
       newCounter: 0
     };

--- a/test/examples/7-localstorage.jsx
+++ b/test/examples/7-localstorage.jsx
@@ -1,8 +1,9 @@
 'use strict';
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
-
+ReactGridLayout = WidthProvider(ReactGridLayout);
 /**
  * This layout demonstrates how to sync to localstorage.
  */
@@ -58,11 +59,11 @@ var LocalStorageLayout = React.createClass({
             {...this.props}
             layout={this.state.layout}
             onLayoutChange={this.onLayoutChange}>
-          <div key={1} _grid={{w: 2, h: 3, x: 0, y: 0}}><span className="text">1</span></div>
-          <div key={2} _grid={{w: 2, h: 3, x: 2, y: 0}}><span className="text">2</span></div>
-          <div key={3} _grid={{w: 2, h: 3, x: 4, y: 0}}><span className="text">3</span></div>
-          <div key={4} _grid={{w: 2, h: 3, x: 6, y: 0}}><span className="text">4</span></div>
-          <div key={5} _grid={{w: 2, h: 3, x: 8, y: 0}}><span className="text">5</span></div>
+          <div key={"1"} _grid={{w: 2, h: 3, x: 0, y: 0}}><span className="text">1</span></div>
+          <div key={"2"} _grid={{w: 2, h: 3, x: 2, y: 0}}><span className="text">2</span></div>
+          <div key={"3"} _grid={{w: 2, h: 3, x: 4, y: 0}}><span className="text">3</span></div>
+          <div key={"4"} _grid={{w: 2, h: 3, x: 6, y: 0}}><span className="text">4</span></div>
+          <div key={"5"} _grid={{w: 2, h: 3, x: 8, y: 0}}><span className="text">5</span></div>
         </ReactGridLayout>
       </div>
     );

--- a/test/examples/8-localstorage-responsive.jsx
+++ b/test/examples/8-localstorage-responsive.jsx
@@ -1,7 +1,9 @@
 'use strict';
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ResponsiveReactGridLayout = require('react-grid-layout').Responsive;
+ResponsiveReactGridLayout = WidthProvider(ResponsiveReactGridLayout);
 
 /**
  * This layout demonstrates how to sync multiple responsive layouts to localstorage.
@@ -56,11 +58,11 @@ var ResponsiveLocalStorageLayout = React.createClass({
         <ResponsiveReactGridLayout
             {...this.props}
             onLayoutChange={this.onLayoutChange}>
-          <div key={1} _grid={{w: 2, h: 3, x: 0, y: 0}}><span className="text">1</span></div>
-          <div key={2} _grid={{w: 2, h: 3, x: 2, y: 0}}><span className="text">2</span></div>
-          <div key={3} _grid={{w: 2, h: 3, x: 4, y: 0}}><span className="text">3</span></div>
-          <div key={4} _grid={{w: 2, h: 3, x: 6, y: 0}}><span className="text">4</span></div>
-          <div key={5} _grid={{w: 2, h: 3, x: 8, y: 0}}><span className="text">5</span></div>
+          <div key={"1"} _grid={{w: 2, h: 3, x: 0, y: 0}}><span className="text">1</span></div>
+          <div key={"2"} _grid={{w: 2, h: 3, x: 2, y: 0}}><span className="text">2</span></div>
+          <div key={"3"} _grid={{w: 2, h: 3, x: 4, y: 0}}><span className="text">3</span></div>
+          <div key={"4"} _grid={{w: 2, h: 3, x: 6, y: 0}}><span className="text">4</span></div>
+          <div key={"5"} _grid={{w: 2, h: 3, x: 8, y: 0}}><span className="text">5</span></div>
         </ResponsiveReactGridLayout>
       </div>
     );

--- a/test/examples/9-min-max-wh.jsx
+++ b/test/examples/9-min-max-wh.jsx
@@ -2,7 +2,9 @@
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
+var WidthProvider = require('react-grid-layout').WidthProvider;
 var ReactGridLayout = require('react-grid-layout');
+ReactGridLayout = WidthProvider(ReactGridLayout);
 
 var MinMaxLayout = React.createClass({
   mixins: [PureRenderMixin],
@@ -43,7 +45,7 @@ var MinMaxLayout = React.createClass({
       var w = _.random(minW, maxW);
       var y = _.random(minH, maxH);
       return {
-        x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i,
+        x: i * 2 % 12, y: Math.floor(i / 6) * y, w: w, h: y, i: i.toString(),
         minW: minW, maxW: maxW, minH: minH, maxH: maxH
       };
     });

--- a/webpack-examples.config.js
+++ b/webpack-examples.config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     module: {
       loaders: [
-        {test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime'}
+        {test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader'}
       ]
     },
     plugins: [


### PR DESCRIPTION
# updated breaking changes

- initialWidth renamed to width
- new HOC Provider logic on `WidthProvider`
- updated tests and docs to `WidthProvider` and component keys of type `String`

I do not like that we need offsetX and offsetY. This only exists because `DraggableCore` returns absolute positions which need to be synced to the grid layout. There must be a better way to solve this.
