### PR TITLE
Fix container height calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you have a feature request, please add it as an issue or make a pull request.
 
 - [AWS CloudFront Dashboards](https://aws.amazon.com/blogs/aws/cloudwatch-dashboards-create-use-customized-metrics-views/)
 - [Metabase](http://www.metabase.com/)
+- [HubSpot](http://www.hubspot.com)
 
 *Know of others? Create a PR to let me know!*
 

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -178,7 +178,7 @@ export default class ReactGridLayout extends React.Component {
    */
   containerHeight() {
     if (!this.props.autoSize) return;
-    return bottom(this.state.layout) * this.props.rowHeight + this.props.margin[1] + 'px';
+    return bottom(this.state.layout) * (this.props.rowHeight + this.props.margin[1]) + 'px';
   }
 
   /**


### PR DESCRIPTION
The container height was only taking the margin into consideration once rather than for each row.

Also added [HubSpot](http://www.hubspot.com) to the list of products that use RGL :+1: :beers: 