### PR TITLE
Synchronize incorrect layout

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -166,7 +166,7 @@ export default class ReactGridLayout extends React.Component {
     // If children change, regenerate the layout.
     if (nextProps.children.length !== this.props.children.length) {
       this.setState({
-        layout: synchronizeLayoutWithChildren(this.state.layout, nextProps.children,
+        layout: synchronizeLayoutWithChildren(nextProps.layout, nextProps.children,
                                               nextProps.cols, nextProps.verticalCompact)
       });
     }


### PR DESCRIPTION
Something I noticed while testing this locally was that [this line](https://github.com/STRML/react-grid-layout/blob/master/lib/ReactGridLayout.jsx#L169) seems to synchronize against the current layout instead of the incoming layout. I would think that you would want to synchronize the next children with their layout and not the current layout. Changing it to `nextProps.layout` seems to fix a lot of issues I had with children not inheriting the correct layout from the grid component parent.

Is this intentional or could this possibly be a typo during the recent big update?