### PR TITLE
Change initial width of WidthProvider to 0

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -11,7 +11,8 @@ type State = {width: number};
 export default (ComposedComponent: ReactClass): ReactClass => class extends React.Component {
 
   state: State = {
-    width: 1280
+    // Intentional; Force RRGL to trigger onBreakpointChange() in any case when mounted
+    width: 0
   };
 
   componentDidMount() {


### PR DESCRIPTION
I had a inconsistency with RRGL with WidthProvider. It always trigger `onBreakpointChange()` when mounted except if the breakpoint deduced from the width of the container was the same as the one deduced from 1280px (initial width of the WidthProvider).

Not sur if it was intentional. But It seems more consistent now because it will always trigger `onBreakpointChange()` after being mounted.

What do you think @STRML ?

I think it solve #93 too.