### PR TITLE
added rowHeightPercent property

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -24,7 +24,8 @@ export default class GridItem extends React.Component {
     // General grid attributes
     cols: PropTypes.number.isRequired,
     containerWidth: PropTypes.number.isRequired,
-    rowHeight: PropTypes.number.isRequired,
+    rowHeight: PropTypes.number,
+    rowHeightPercent: PropTypes.number,
     margin: PropTypes.array.isRequired,
     maxRows: PropTypes.number.isRequired,
 
@@ -115,8 +116,14 @@ export default class GridItem extends React.Component {
    * @return {Object}                Object containing coords.
    */
   calcPosition(x: number, y: number, w: number, h: number, state: ?Object): Position {
-    const {margin, rowHeight} = this.props;
+    const {margin, rowHeightPercent} = this.props;
     const colWidth = this.calcColWidth();
+    var rowHeight;
+    if (rowHeightPercent) {
+      rowHeight = colWidth * rowHeightPercent / 100;
+    } else {
+      rowHeight = this.props.rowHeight;
+    }
 
     const out = {
       left: Math.round(colWidth * x + (x + 1) * margin[0]),

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -67,6 +67,8 @@ export default class ReactGridLayout extends React.Component {
     margin: PropTypes.arrayOf(PropTypes.number),
     // Rows have a static height, but you can change this based on breakpoints if you like
     rowHeight: PropTypes.number,
+    // Alternatively you can set the row height as percent of the column width. This overwrites the rowHeight property.
+    rowHeightPercent: PropTypes.number,
     // Default Infinity, but you can specify a max here if you like.
     // Note that this isn't fully fleshed out and won't error if you specify a layout that
     // extends beyond the row capacity. It will, however, not allow users to drag/resize
@@ -193,7 +195,14 @@ export default class ReactGridLayout extends React.Component {
    */
   containerHeight() {
     if (!this.props.autoSize) return;
-    return bottom(this.state.layout) * (this.props.rowHeight + this.props.margin[1]) + this.props.margin[1] + 'px';
+    var rowHeight;
+    if (this.props.rowHeightPercent) {
+      var colWidth = (this.props.width - (this.props.margin[0] * (this.props.cols + 1))) / this.props.cols;
+      rowHeight = colWidth * this.props.rowHeightPercent / 100;
+    } else {
+      rowHeight = this.props.rowHeight;
+    }
+    return bottom(this.state.layout) * (rowHeight + this.props.margin[1]) + this.props.margin[1] + 'px';
   }
 
   /**
@@ -326,7 +335,7 @@ export default class ReactGridLayout extends React.Component {
   placeholder(): ?React.Element {
     const {activeDrag} = this.state;
     if (!activeDrag) return null;
-    const {width, cols, margin, rowHeight, maxRows, useCSSTransforms} = this.props;
+    const {width, cols, margin, rowHeight, rowHeightPercent, maxRows, useCSSTransforms} = this.props;
 
     // {...this.state.activeDrag} is pretty slow, actually
     return (
@@ -342,6 +351,7 @@ export default class ReactGridLayout extends React.Component {
         margin={margin}
         maxRows={maxRows}
         rowHeight={rowHeight}
+        rowHeightPercent={rowHeightPercent}
         isDraggable={false}
         isResizable={false}
         useCSSTransforms={useCSSTransforms}>
@@ -359,7 +369,7 @@ export default class ReactGridLayout extends React.Component {
     if (!child.key) return;
     const l = getLayoutItem(this.state.layout, child.key);
     if (!l) return null;
-    const {width, cols, margin, rowHeight, maxRows, isDraggable, isResizable,
+    const {width, cols, margin, rowHeight, rowHeightPercent, maxRows, isDraggable, isResizable,
            useCSSTransforms, draggableCancel, draggableHandle} = this.props;
 
     // Parse 'static'. Any properties defined directly on the grid item will take precedence.
@@ -373,6 +383,7 @@ export default class ReactGridLayout extends React.Component {
         margin={margin}
         maxRows={maxRows}
         rowHeight={rowHeight}
+        rowHeightPercent={rowHeightPercent}
         cancel={draggableCancel}
         handle={draggableHandle}
         onDragStop={this.onDragStop}


### PR DESCRIPTION
For our product it is important that cells are square and the grid remains responsive, so we can not use a pixel value for the `rowHeight` property. To solve this, we added a `rowHeightPercent` property as an alternative, which overwrites the `rowHeight` behavior. Setting this to `100` results in a row height equal to the cells column width.