### PR TITLE
update react grid when filled with new cols or new breakpoints

### DIFF
--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -91,7 +91,11 @@ export default class ResponsiveReactGridLayout extends React.Component {
   componentWillReceiveProps(nextProps: Object) {
 
     // Allow parent to set width or breakpoint directly.
-    if (nextProps.width != this.props.width || nextProps.breakpoint !== this.props.breakpoint) {
+    if (nextProps.width != this.props.width 
+    || nextProps.breakpoint !== this.props.breakpoint
+    || nextProps.breakpoints !== this.props.breakpoints
+    || nextProps.cols !== this.props.cols
+    ) {
       this.onWidthChange(nextProps);
     }
 
@@ -124,9 +128,11 @@ export default class ResponsiveReactGridLayout extends React.Component {
     const newBreakpoint = nextProps.breakpoint || getBreakpointFromWidth(nextProps.breakpoints, nextProps.width);
 
     const lastBreakpoint = this.state.breakpoint;
-
+    const lastBreakpoints = this.state.breakpoints;
+    const lastCols = this.state.cols;
+    
     // Breakpoint change
-    if (lastBreakpoint !== newBreakpoint) {
+    if (lastBreakpoint !== newBreakpoint || lastBreakpoints !== nextProps.breakpoints || lastCols !== nextProps.cols) {
 
       // Store the current layout
       const layouts = nextProps.layouts;


### PR DESCRIPTION
Hey!!

This settled [Rendering with new Breakpoints props do not refresh the layout](https://github.com/STRML/react-grid-layout/issues/208).

Let me know if you find anything wrong with this code. I test it through `npm run dev`. It looks fine for me.

Thank you