### PR TITLE
avoid having props.layouts.lg static overriden

### DIFF
--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -95,6 +95,7 @@ export default class ResponsiveReactGridLayout extends React.Component {
     || nextProps.breakpoint !== this.props.breakpoint
     || nextProps.breakpoints !== this.props.breakpoints
     || nextProps.cols !== this.props.cols
+    || nextProps.rowHeight !== this.props.rowHeight
     ) {
       this.onWidthChange(nextProps);
     }
@@ -132,7 +133,7 @@ export default class ResponsiveReactGridLayout extends React.Component {
     const lastCols = this.state.cols;
     
     // Breakpoint change
-    if (lastBreakpoint !== newBreakpoint || lastBreakpoints !== nextProps.breakpoints || lastCols !== nextProps.cols) {
+    if (lastBreakpoint !== newBreakpoint || lastBreakpoints !== nextProps.breakpoints || lastCols !== nextProps.cols || this.state.rowHeight !==nextProps.rowHeight) {
 
       // Store the current layout
       const layouts = nextProps.layouts;

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -136,7 +136,7 @@ export default class ResponsiveReactGridLayout extends React.Component {
 
       // Store the current layout
       const layouts = nextProps.layouts;
-      layouts[lastBreakpoint] = cloneLayout(this.state.layout);
+      layouts[lastBreakpoint] = cloneLayout(layouts[lastBreakpoint]);
 
       // Find or generate a new one.
       const newCols: number = getColsFromBreakpoint(newBreakpoint, cols);


### PR DESCRIPTION
Hello

When changing the prop `static` on the layouts items I sent to `<ResponsiveReactGridLayout>`, I saw that the prop `static` was never take into account. So I made a modification to, for example, avoid having `props.layouts.lg` overriden by `this.state.layout` in case a new layouts was sent to `<ResponsiveReactGridLayout>` through `layouts`.

Thank you
