### PR TITLE
Substract paddings from node in WidthProvider

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -44,7 +44,14 @@ export default (ComposedComponent: ReactClass): ReactClass => class extends Reac
 
   onWindowResize = (_event: Event, cb: ?Function) => {
     const node = ReactDOM.findDOMNode(this);
-    this.setState({width: node.offsetWidth}, cb);
+    
+    let padLeft = window.getComputedStyle(node, null).getPropertyValue('padding-left') || 0;
+    padLeft = parseInt(padLeft) || 0;
+
+    let padRight = window.getComputedStyle(node, null).getPropertyValue('padding-right') || 0;
+    padRight = parseInt(padRight) || 0;
+    
+    this.setState({width: node.offsetWidth - padLeft - padRight}, cb);
   }
 
   render() {


### PR DESCRIPTION
I have the problem that my container object has some padding which I like to keep. This leads to a wrong calculated width, since the content should be only rendered inside the padding. This code should Substrat any paddings.