### PR TITLE
Update  layouts[lastBreakpoint] at the right time

### DIFF
--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -132,10 +132,10 @@ export default class ResponsiveReactGridLayout extends React.Component {
 
     // Breakpoint change
     if (lastBreakpoint !== newBreakpoint || this.props.breakpoints !== breakpoints || this.props.cols !== cols) {
-
-      // Store the current layout
       const layouts = nextProps.layouts;
-      layouts[lastBreakpoint] = cloneLayout(this.state.layout);
+      
+      // save the current layout before any modification
+      var _lastLayout = = cloneLayout(this.state.layout);
 
       // Find or generate a new one.
       const newCols: number = getColsFromBreakpoint(newBreakpoint, cols);
@@ -145,6 +145,9 @@ export default class ResponsiveReactGridLayout extends React.Component {
       // This adds missing items.
       layout = synchronizeLayoutWithChildren(layout, nextProps.children, newCols, verticalCompact);
 
+      // Store the last layout
+      layouts[lastBreakpoint] = _lastLayout;
+      
       // Store this new layout as well.
       layouts[newBreakpoint] = layout;
 


### PR DESCRIPTION
I met a problem when changing the number of cols given as props. It recalculates the layout not using the layouts given in props but using the already modified layout present in `this.state`. I did a modification to have `findOrGenerateResponsiveLayout` using the `layouts` not yet modified. With this problem resolved, I can change the number of cols -1 then +1 and have the layout displayed as before. I have deliver a demo of this [builder](http://damienleroux.github.io/react-grid-layout-builder/demo/). Let me know what you think of it :)
