### PR TITLE
Prevent prop layout's contents from being modified

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -358,7 +358,7 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
     // Don't overwrite if it already exists.
     const exists = getLayoutItem(initialLayout, child.key || "1" /* FIXME satisfies Flow */);
     if (exists) {
-      newItem = exists;
+      newItem = cloneLayoutItem(exists);
     } else {
       const g = child.props._grid;
 


### PR DESCRIPTION
When given a `layout` prop, react-grid-layout calls `synchronizeLayoutWithChildren` with the layout prop as an argument.

`synchronizeLayoutWithChildren` calls
```js
const exists = getLayoutItem(initialLayout, child.key || "1" /* FIXME satisfies Flow */)
```

which sets into `exists` a layout item object (equivalent, for exemple, to `this.props.layout[i]`)
This item is then directly set into the new layout, and manipulated (the values of y are modified when packing vertically for example)

Hovever, the object representing the item was always passed by reference, and never cloned. This results into `this.props.layout` objects being directly mutated, which shouldn't happen.

This PR aims to fix that error.