### PR TITLE
Issue #266 - Expanded example text regarding the use of draggableHandle

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,13 @@ autoSize: ?boolean = true,
 cols: ?number = 12,
 
 // A selector that will not be draggable.
+// For example: draggableCancel:'.MyNonDraggableAreaClassName'
+// If you forget the leading . it will not work.
 draggableCancel: ?string = '',
+
 // A selector for the draggable handler
+// For example: draggableHandle:'.MyDragHandleClassName'
+// If you forget the leading . it will not work.
 draggableHandle: ?string = '',
 
 // If true, the layout will compact vertically

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ autoSize: ?boolean = true,
 // Number of columns in this layout.
 cols: ?number = 12,
 
-// A selector that will not be draggable.
+// A CSS selector for tags that will not be draggable.
 // For example: draggableCancel:'.MyNonDraggableAreaClassName'
 // If you forget the leading . it will not work.
 draggableCancel: ?string = '',
 
-// A selector for the draggable handler
+// A CSS selector for tags that will act as the draggable handle.
 // For example: draggableHandle:'.MyDragHandleClassName'
 // If you forget the leading . it will not work.
 draggableHandle: ?string = '',

--- a/examples/example-styles.css
+++ b/examples/example-styles.css
@@ -47,3 +47,9 @@ body {
 .react-grid-item .add {
   cursor: pointer;
 }
+.react-grid-dragHandleExample{
+  cursor: move; /* fallback if grab cursor is unsupported */
+  cursor: grab;
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+}

--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -26,7 +26,13 @@ var StaticElementsLayout = React.createClass({
         <div key="1" _grid={{x: 0, y: 0, w: 2, h: 3}}><span className="text">1</span></div>
         <div key="2" _grid={{x: 2, y: 0, w: 4, h: 3, static: true}}><span className="text">2 - Static</span></div>
         <div key="3" _grid={{x: 6, y: 0, w: 2, h: 3}}><span className="text">3</span></div>
-        <div key="4" _grid={{x: 2, y: 0, w: 4, h: 3, draggableHandle: '.react-grid-dragHandleExample'}}><span className="text">4 - Draggable with Handle<hr/><hr/><span className={}>[DRAG HERE]<hr/><hr></span></div>
+        <div key="4" _grid={{x: 2, y: 0, w: 4, h: 3, draggableHandle: '.react-grid-dragHandleExample'}}>
+          <span className="text">4 - Draggable with Handle
+            <hr/><hr/>
+            <span className='react-grid-dragHandleExample'>[DRAG HERE]</span>
+            <hr/><hr/>
+          </span>
+        </div>
       </ReactGridLayout>
     );
   }

--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -26,6 +26,7 @@ var StaticElementsLayout = React.createClass({
         <div key="1" _grid={{x: 0, y: 0, w: 2, h: 3}}><span className="text">1</span></div>
         <div key="2" _grid={{x: 2, y: 0, w: 4, h: 3, static: true}}><span className="text">2 - Static</span></div>
         <div key="3" _grid={{x: 6, y: 0, w: 2, h: 3}}><span className="text">3</span></div>
+        <div key="4" _grid={{x: 2, y: 0, w: 4, h: 3, draggableHandle: '.react-grid-dragHandleExample'}}><span className="text">4 - Draggable with Handle<hr/><hr/><span className={}>[DRAG HERE]<hr/><hr></span></div>
       </ReactGridLayout>
     );
   }

--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -26,7 +26,7 @@ var StaticElementsLayout = React.createClass({
         <div key="1" _grid={{x: 0, y: 0, w: 2, h: 3}}><span className="text">1</span></div>
         <div key="2" _grid={{x: 2, y: 0, w: 4, h: 3, static: true}}><span className="text">2 - Static</span></div>
         <div key="3" _grid={{x: 6, y: 0, w: 2, h: 3}}><span className="text">3</span></div>
-        <div key="4" _grid={{x: 2, y: 0, w: 4, h: 3, draggableHandle: '.react-grid-dragHandleExample'}}>
+        <div key="4" _grid={{x: 8, y: 0, w: 4, h: 3, draggableHandle: '.react-grid-dragHandleExample'}}>
           <span className="text">4 - Draggable with Handle
             <hr/><hr/>
             <span className='react-grid-dragHandleExample'>[DRAG HERE]</span>


### PR DESCRIPTION
This change adds a tiny bit of commenting on the README.md to show that in the className you do not need the leading . character, however in the draggableHandle option you do need the leading dot.  Otherwise, the draggableHandle will not work.   

It seems kind of obvious in retrospect, but I lost over an hour trying to figure it out.  

This also adds to the static box example to create another grid item that can only be dragged by the handle.

Thank you for your patience.  
I am new to JavaScript and GitHub.  This is my first attempt at a pull request.  