### PR TITLE
use lodash to check object equality, prevents onLayoutChange loop

### DIFF
--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -94,8 +94,8 @@ export default class ResponsiveReactGridLayout extends React.Component {
     if (
          nextProps.width != this.props.width
       || nextProps.breakpoint !== this.props.breakpoint
-      || nextProps.breakpoints !== this.props.breakpoints
-      || nextProps.cols !== this.props.cols
+      || !isEqual(nextProps.breakpoints, this.props.breakpoints)
+      || !isEqual(nextProps.cols, this.props.cols)
     ) {
       this.onWidthChange(nextProps);
     }


### PR DESCRIPTION
Currently tries to do equality check on two objects (breakpoints, cols) this will always return false.  When using redux (or anything that would change props on layout change) onLayoutChange causes a loop due to always thinking it needs to run onWidthChange