### PR TITLE
Add WidthProvider option to await nonzero width

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -5,7 +5,8 @@ import ReactDOM from 'react-dom';
 
 type State = {
   mounted: boolean,
-  width: number
+  width: number,
+  widthFound: boolean,
 };
 
 /*
@@ -14,18 +15,29 @@ type State = {
 export default (ComposedComponent: ReactClass): ReactClass => class extends React.Component {
 
   static defaultProps = {
-    measureBeforeMount: false
+    measureBeforeMount: false,
+    awaitNonzeroWidth: false,
+    nonzeroWidthRetryDelay: 50,
+    nonzeroWidthMaxWait: 2000,
   };
 
   static propTypes = {
     // If true, will not render children until mounted. Useful for getting the exact width before
     // rendering, to prevent any unsightly resizing.
-    measureBeforeMount: React.PropTypes.bool
+    measureBeforeMount: React.PropTypes.bool,
+
+    // If true, will not render children until a nonzero width is detected (or maxDelay has been exceeded)
+    awaitNonzeroWidth: React.PropTypes.bool,
+    // Millisecond delay between checks for nonzero width
+    nonzeroWidthRetryDelay: React.PropTypes.number,
+    // Max time in milliseconds to check for nonzero width
+    nonzeroWidthMaxWait: React.PropTypes.number,
   };
 
   state: State = {
     mounted: false,
-    width: 1280
+    width: 1280,
+    widthFound: false,
   };
 
   componentDidMount() {
@@ -44,11 +56,32 @@ export default (ComposedComponent: ReactClass): ReactClass => class extends Reac
 
   onWindowResize = (_event: Event, cb: ?Function) => {
     const node = ReactDOM.findDOMNode(this);
-    this.setState({width: node.offsetWidth}, cb);
+    const width = node.offsetWidth;
+    if (!this.props.awaitNonzeroWidth || this.state.widthFound || width != 0) {
+      this.setState({width, widthFound: true}, cb);
+    }
+    else {
+      let loopCounter = 0;
+      const that = this;
+      const waitForNonZeroWidth = function() {
+        const node = ReactDOM.findDOMNode(that);
+        const width = node.offsetWidth;
+        if (width == 0) {
+          loopCounter++;
+          const wait = loopCounter++ * that.props.nonzeroWidthRetryDelay;
+          if (wait >= that.props.nonzeroWidthMaxWait) that.setState({widthFound: true}, cb);
+          else setTimeout(waitForNonZeroWidth, that.props.nonzeroWidthRetryDelay);
+        }
+        else that.setState({width, widthFound: true}, cb);
+      };
+      waitForNonZeroWidth();
+    }
   }
 
   render() {
-    if (this.props.measureBeforeMount && !this.state.mounted) return <div {...this.props} {...this.state} />;
+    // the internal <div /> prevents child components from being rendered too early
+    if (this.props.awaitNonzeroWidth && !this.state.widthFound) return <div {...this.props} {...this.state} ><div /></div>;
+    else if (this.props.measureBeforeMount && !this.state.mounted) return <div {...this.props} {...this.state} />;
     return <ComposedComponent {...this.props} {...this.state} />;
   }
 };


### PR DESCRIPTION
This branch adds an option to WidthProvider to have it wait until the initially rendered &lt;div&gt; has a nonzero width before rendering the actual &lt;ComposedComponent&gt;.  There are also options controlling how often it polls for a nonzero width (default is 50 ms) and how long to poll before giving up (default is 2000 ms).  I needed this capability because I had RGLs (actually RRGLs) inside a tab component, and when switching tabs, WidthProvider saw an initial width of zero (since the new tab content area wasn't fully rendered yet) and the RRGL was rendered to that zero width.  So the RRGL was never visible since it never saw that the tab content width changed.

You'll also notice that I add an internal &lt;div&gt; as a child of the initially rendered &lt;div&gt;.  This prevents children of the &lt;ComposedComponent&gt; from being rendered before the width is properly set.  You may want to add that to the &lt;div&gt; in the measureBeforeMount case as well, although in that case the short interval between the first two render() calls makes it very unlikely that a user will observe the children before the second render.