### PR TITLE
fix onLayoutChange call too often #257

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -274,7 +274,7 @@ export default class ReactGridLayout extends React.Component {
       oldDragItem: null
     });
 
-    this.props.onLayoutChange(this.state.layout);
+    if (!isEqual(oldDragItem, l)) this.props.onLayoutChange(this.state.layout);
   }
 
   onResizeStart(i:string, w:number, h:number, {e, node}: ResizeEvent) {


### PR DESCRIPTION
Prevent the onDragStop to call the onLayoutChange before it has done checking if an old item and a new one is not the same.

#257 