### PR TITLE
Why do we pass props and state to measureBeforeMount <div /> in WidthProvider?

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -48,7 +48,10 @@ export default (ComposedComponent: ReactClass): ReactClass => class extends Reac
   }
 
   render() {
-    if (this.props.measureBeforeMount && !this.state.mounted) return <div {...this.props} {...this.state} />;
+    if (this.props.measureBeforeMount && !this.state.mounted) {
+      return <div className={this.props.className} style={this.props.style} />;
+    }
+
     return <ComposedComponent {...this.props} {...this.state} />;
   }
 };


### PR DESCRIPTION
I'm curious about the reasoning is behind passing `this.props` and `this.state` to the `<div />` in `WidthProvider`.

So it seems to mount the grid components (via `this.props.children`), then remount them once `this.state.mounted` is true. This is presenting a problem for me since my grid components are stateful, and fire a async HTTP call on mount that results in a `setState(...)`. 

When the `setState(...)` occurs, the original instance has been unmounted so React fires an error in the console.

What are the reasons behind this, and the tradeoffs preventing it from being removed?