### PR TITLE
Prevent utils.synchronizeLayoutWithChildren() from forcing components to collide

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,6 +118,11 @@ export function compact(layout: Layout, verticalCompact: boolean): Layout {
  */
 export function compactItem(compareWith: Layout, l: LayoutItem, verticalCompact: boolean): LayoutItem {
   if (verticalCompact) {
+    // Bottom 'y' possible is the bottom of the layout.
+    // This allows you to do nice stuff like specify {y: Infinity}
+    // This is is here because it the layout must be sorted in order to get the correct bottom `y`.
+    l.y = Math.min(bottom(compareWith), l.y);
+
     // Move the element up as far as it can go without colliding.
     while (l.y > 0 && !getFirstCollision(compareWith, l)) {
       l.y--;
@@ -378,13 +383,8 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
         if (!isProduction) {
           validateLayout([g], 'ReactGridLayout.children');
         }
-        // Validated; add it to the layout. Bottom 'y' possible is the bottom of the layout.
-        // This allows you to do nice stuff like specify {y: Infinity}
-        if (verticalCompact) {
-          newItem = cloneLayoutItem({...g, y: Math.min(bottom(layout), g.y), i: child.key});
-        } else {
-          newItem = cloneLayoutItem({...g, y: g.y, i: child.key});
-        }
+
+        newItem = cloneLayoutItem({...g, i: child.key});
       }
       // Nothing provided: ensure this is added to the bottom
       else {


### PR DESCRIPTION
Hey Samuel,

We just deployed RGL to production at Reflect, and wanted to thank you for your work. 👏  Shortly after deploying we found a pretty bad bug that I wanted to surface to you.

We've been running into a problem where sometimes, the grid that is rendered is
different than the grid we specify through `layout`. We found this could be
fixed by reversing the order in which we pass our children grid items to RGL,
which led us to believe there was a bug in RGL that was modifying `y`.

After some debugging, we found `utils.synchronizeLayoutWithChildren()`
to be the culprit.

As an example, here's the layout we were providing:

```javascript
[
  { x: 0, y: 1, w: 4, h: 2 },
  { x: 0, y: 0, w: 4, h: 1 }
];
```

When rendered, the first item should visually be below the second. However,
since `synchronizeLayoutWithChildren` synchronizes the layout in the order
it is provided, it was updating the `y` property of the first item
to be `Math.min(bottom(layout), g.y),`, which would end up equaling 0.

This meant that (when `static` was `false`), RGL would eventually recognize
the new collision and update the second item to be visually below the first,
by setting its `y` value to 2.

This was resulting in the grid looking like this:

```javascript
[
  { x: 0, y: 0, w: 4, h: 2 },
  { x: 0, y: 2, w: 4, h: 1 }
];
```

My proposed change moves this logic down into the `utils.compactItem()`
function, since the layout has been sorted by the time this function is
called. Because we're now iterating through the items after they've been
sorted, this is no longer a problem and the correct grid is rendered.