### PR TITLE
Add preventCollision option

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-lib/
 test/
 examples/
 dist/

--- a/.npmignore
+++ b/.npmignore
@@ -3,8 +3,6 @@ examples/
 dist/
 yarn.lock
 .github
-*.config.js
-Makefile
 *.sh
 *.*.json
 __tests__/

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -80,6 +80,10 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     // A selector for the draggable handler
     draggableHandle: PropTypes.string,
 
+    // If true, grid items won't change position when being
+    // dragged over.
+    preventCollision: PropTypes.bool,
+
     // If true, the layout will compact vertically
     verticalCompact: PropTypes.bool,
 
@@ -273,7 +277,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     };
 
     // Move the element to the dragged location.
-    layout = moveElement(layout, l, x, y, true /* isUserAction */);
+    layout = moveElement(layout, l, x, y, true, this.props.preventCollision);
 
     this.props.onDrag(layout, oldDragItem, l, placeholder, e, node);
 
@@ -298,7 +302,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     if (!l) return;
 
     // Move the element here
-    layout = moveElement(layout, l, x, y, true /* isUserAction */);
+    layout = moveElement(layout, l, x, y, true, this.props.preventCollision);
 
     this.props.onDragStop(layout, oldDragItem, l, null, e, node);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -228,12 +228,13 @@ export function getStatics(layout: Layout): Array<LayoutItem> {
  * @param  {Boolean}    [isUserAction] If true, designates that the item we're moving is
  *                                     being dragged/resized by the user.
  */
-export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?number, isUserAction: ?boolean): Layout {
+export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?number, isUserAction: ?boolean, preventCollision: ?boolean): Layout {
   if (l.static) return layout;
 
   // Short-circuit if nothing to do.
   if (l.y === y && l.x === x) return layout;
 
+  const oldX = l.x;
   const movingUp = y && l.y > y;
   // This is quite a bit faster than extending the object
   if (typeof x === 'number') l.x = x;
@@ -252,6 +253,10 @@ export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?numbe
   for (let i = 0, len = collisions.length; i < len; i++) {
     const collision = collisions[i];
     // console.log('resolving collision between', l.i, 'at', l.y, 'and', collision.i, 'at', collision.y);
+    if (preventCollision) {
+      l.x = oldX;
+      return layout;
+    }
 
     // Short circuit so we can't infinite loop
     if (collision.moved) continue;


### PR DESCRIPTION
This option prevents grid items from being moved when collided with. This
is useful functionality for the video sequencer I'm building with
react-grid-layout.
