### PR TITLE
Remove lib/ and Makefile from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,8 @@
-lib/
 test/
 examples/
 dist/
 yarn.lock
 .github
 *.config.js
-Makefile
 *.sh
 *.*.json


### PR DESCRIPTION


Ignoring these files prevents the ability to use custom branches of react-grid-layout via a GitHub url, like this: https://github.com/ccnmtl/juxtapose/blob/master/package.json#L30

Without `lib/` and `Makefile`, the custom build fails.