### PR TITLE
Use isProduction const where available

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -369,7 +369,7 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: R
     if (exists) {
       layout[i] = cloneLayoutItem(exists);
     } else {
-      if (process.env.NODE_ENV !== 'production' && child.props._grid) {
+      if (!isProduction && child.props._grid) {
         console.warn('`_grid` properties on children have been deprecated as of React 15.2. ' + // eslint-disable-line
           'Please use `data-grid` or add your properties directly to the `layout`.');
       }


### PR DESCRIPTION
Since this is already defined at the top of the file, we can use this variable in
synchronizeLayoutWithChildren instead of looking it up again.