### PR TITLE
isStateless prop added

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -81,6 +81,7 @@ export default class ReactGridLayout extends React.Component {
     // Flags
     //
     isDraggable: PropTypes.bool,
+    isStateless: PropTypes.bool,
     isResizable: PropTypes.bool,
     // Use CSS transforms instead of top/left
     useCSSTransforms: PropTypes.bool,
@@ -134,6 +135,7 @@ export default class ReactGridLayout extends React.Component {
     layout: [],
     margin: [10, 10],
     isDraggable: true,
+    isStateless: false,
     isResizable: true,
     useCSSTransforms: true,
     verticalCompact: true,
@@ -271,14 +273,16 @@ export default class ReactGridLayout extends React.Component {
     this.props.onDragStop(layout, oldDragItem, l, null, e, node);
 
     // Set state
-    const newLayout = compact(layout, this.props.verticalCompact);
-    const {oldLayout} = this.state;
-    this.setState({
-      activeDrag: null,
-      layout: newLayout,
-      oldDragItem: null,
-      oldLayout: null,
-    });
+    if (!this.props.stateLess) {
+      const newLayout = compact(layout, this.props.verticalCompact);
+      const {oldLayout} = this.state;
+      this.setState({
+        activeDrag: null,
+        layout: newLayout,
+        oldDragItem: null,
+        oldLayout: null,
+      });
+    }
 
     this.onLayoutMaybeChanged(newLayout, oldLayout);
   }
@@ -332,15 +336,17 @@ export default class ReactGridLayout extends React.Component {
 
     this.props.onResizeStop(layout, oldResizeItem, l, null, e, node);
 
-    // Set state
-    const newLayout = compact(layout, this.props.verticalCompact);
-    const {oldLayout} = this.state;
-    this.setState({
-      activeDrag: null,
-      layout: newLayout,
-      oldResizeItem: null,
-      oldLayout: null
-    });
+    if (!this.props.stateLess) {
+      // Set state
+      const newLayout = compact(layout, this.props.verticalCompact);
+      const {oldLayout} = this.state;
+      this.setState({
+        activeDrag: null,
+        layout: newLayout,
+        oldResizeItem: null,
+        oldLayout: null
+      });
+    }
 
     this.onLayoutMaybeChanged(newLayout, oldLayout);
   }


### PR DESCRIPTION
for the case, when you use redux to process and store layout - you pass new layout through props and internal state layout should not rewrite the one source of trooth

