### PR TITLE
fix bug

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+  "node": true,
+
+  "curly": true,
+  "latedef": true,
+  "quotmark": true,
+  "undef": true,
+  "unused": true,
+  "trailing": true
+}

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -392,8 +392,8 @@ export default class ReactGridLayout extends React.Component {
     const {mounted} = this.state;
 
     // Parse 'static'. Any properties defined directly on the grid item will take precedence.
-    const draggable = Boolean(!l.static && isDraggable && (l.isDraggable || l.isDraggable == null));
-    const resizable = Boolean(!l.static && isResizable && (l.isResizable || l.isResizable == null));
+      const draggable = Boolean(l.isDraggable || l.static || isDraggable);
+      const resizable = Boolean(l.isResizable || l.static || isResizable);
 
     return (
       <GridItem


### PR DESCRIPTION
This is the first time I send pull request. I dun know any rules and I am developing in window so I dun know why there are some additional files changed. 

But I just want to point out the grid item default props: draggable and resizable do not work as what the document wrote 
