### PR TITLE
Fix lint warnings

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -37,25 +37,25 @@ export default class GridItem extends React.Component {
     h: PropTypes.number.isRequired,
 
     // All optional
-    minW: function (props, propName, componentName) {
+    minW: function (props, propName) {
       const value = props[propName];
       if (typeof value !== 'number') return new Error('minWidth not Number');
       if (value > props.w || value > props.maxW) return new Error('minWidth larger than item width/maxWidth');
     },
 
-    maxW: function (props, propName, componentName) {
+    maxW: function (props, propName) {
       const value = props[propName];
       if (typeof value !== 'number') return new Error('maxWidth not Number');
       if (value < props.w || value < props.minW) return new Error('maxWidth smaller than item width/minWidth');
     },
 
-    minH: function (props, propName, componentName) {
+    minH: function (props, propName) {
       const value = props[propName];
       if (typeof value !== 'number') return new Error('minHeight not Number');
       if (value > props.h || value > props.maxH) return new Error('minHeight larger than item height/maxHeight');
     },
 
-    maxH: function (props, propName, componentName) {
+    maxH: function (props, propName) {
       const value = props[propName];
       if (typeof value !== 'number') return new Error('maxHeight not Number');
       if (value < props.h || value < props.minH) return new Error('maxHeight smaller than item height/minHeight');


### PR DESCRIPTION
This fixes 4 flow warnings:

    warning  'componentName' is defined but never used  no-unused-vars

