### PR TITLE
[BUG] CSS is case sensitive

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -312,7 +312,7 @@ export function setTransform({top, left, width, height}: Position): Object {
     transform: translate,
     WebkitTransform: translate,
     MozTransform: translate,
-    msTransform: translate,
+    MSTransform: translate,
     OTransform: translate,
     width: `${width}px`,
     height: `${height}px`,


### PR DESCRIPTION
Not doing this can result into this error:

`Prop style passed to Widget. Has invalid keys msTransform`.