### PR TITLE
Enable hidden widgets  - Enhancing performance of grid

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,9 +49,9 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
   return {
     w: layoutItem.w, h: layoutItem.h, x: layoutItem.x, y: layoutItem.y, i: layoutItem.i,
     minW: layoutItem.minW, maxW: layoutItem.maxW, minH: layoutItem.minH, maxH: layoutItem.maxH,
-    moved: Boolean(layoutItem.moved), static: Boolean(layoutItem.static),
+    moved: Boolean(layoutItem.moved), static: Boolean(layoutItem.static)
     // These can be null
-    isDraggable: layoutItem.isDraggable, isResizable: layoutItem.isResizable
+    isDraggable: layoutItem.isDraggable, isResizable: layoutItem.isResizable, hidden:layoutItem.hidden
   };
 }
 
@@ -96,7 +96,7 @@ export function compact(layout: Layout, verticalCompact: boolean): Layout {
     let l = cloneLayoutItem(sorted[i]);
 
     // Don't move static elements
-    if (!l.static) {
+    if (!l.static && !l.hidden) {
       l = compactItem(compareWith, l, verticalCompact);
 
       // Add to comparison array. We only collide with items before this one.


### PR DESCRIPTION
I had a use case at work to use a grid layout and stumble upon this great library.

However, for that particular use case I am required to have all widgets mounted (visible/hidden) and flip their visibility dynamically, while clicking in different tabs. 

There are 20 tabs and each tab has about 20 grid items. Flipping between the tabs currently requires mounting/unmounting of the different griditems.

The change I have done is actually to render the grid items but only display the grid items that are required. This is all done by adding an additional "hidden" provided to data-grid object, which is used by the util.js to consider "hidden" elements same as static (in terms of calculation of x,y,width,height).

The result is a grid which has hidden widgets and can hide/show the widgets without needing to mount/unmount them which makes the overall application blazing fast.

As this is my first PR in this library, do let me know if this explanation is sufficient or there is anything else I need to do.

Kind Regards
Junio