### PR TITLE
Change PropTypes import to use prop-types instead of react. Fixes #538

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {DraggableCore} from 'react-draggable';
 import {Resizable} from 'react-resizable';
 import {perc, setTopLeft, setTransform} from './utils';

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import classNames from 'classnames';
 import {autoBindHandlers, bottom, childrenEqual, cloneLayoutItem, compact, getLayoutItem, moveElement,

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 
 import {cloneLayout, synchronizeLayoutWithChildren, validateLayout} from './utils';
@@ -28,13 +29,13 @@ export default class ResponsiveReactGridLayout extends React.Component {
 
     // Optional, but if you are managing width yourself you may want to set the breakpoint
     // yourself as well.
-    breakpoint: React.PropTypes.string,
+    breakpoint: PropTypes.string,
 
     // {name: pxVal}, e.g. {lg: 1200, md: 996, sm: 768, xs: 480}
-    breakpoints: React.PropTypes.object,
+    breakpoints: PropTypes.object,
 
     // # of cols. This is a breakpoint -> cols map
-    cols: React.PropTypes.object,
+    cols: PropTypes.object,
 
     // layouts is an object mapping breakpoints to layouts.
     // e.g. {lg: Layout, md: Layout, ...}
@@ -52,21 +53,21 @@ export default class ResponsiveReactGridLayout extends React.Component {
 
     // The width of this component.
     // Required in this propTypes stanza because generateInitialState() will fail without it.
-    width: React.PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
 
     //
     // Callbacks
     //
 
     // Calls back with breakpoint and new # cols
-    onBreakpointChange: React.PropTypes.func,
+    onBreakpointChange: PropTypes.func,
 
     // Callback so you can save the layout.
     // Calls back with (currentLayout, allLayouts). allLayouts are keyed by breakpoint.
-    onLayoutChange: React.PropTypes.func,
+    onLayoutChange: PropTypes.func,
 
     // Calls back with (containerWidth, margin, cols, containerPadding)
-    onWidthChange: React.PropTypes.func
+    onWidthChange: PropTypes.func
   };
 
   static defaultProps = {

--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 type State = {
@@ -19,7 +20,7 @@ const WidthProvider: ProviderT = (ComposedComponent) => class extends React.Comp
   static propTypes = {
     // If true, will not render children until mounted. Useful for getting the exact width before
     // rendering, to prevent any unsightly resizing.
-    measureBeforeMount: React.PropTypes.bool
+    measureBeforeMount: PropTypes.bool
   };
 
   state: State = {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash.isequal": "^4.0.0",
+    "prop-types": "^15.5.8",
     "react-draggable": "^2.1.1",
     "react-resizable": "^1.4.0"
   },
@@ -67,7 +68,6 @@
     "lodash": "^4.3.0",
     "pre-commit": "^1.1.2",
     "precommit-hook": "^3.0.0",
-    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-hot-loader": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lodash": "^4.3.0",
     "pre-commit": "^1.1.2",
     "precommit-hook": "^3.0.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-hot-loader": "^1.3.0",

--- a/test/examples/0-showcase.jsx
+++ b/test/examples/0-showcase.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {Responsive, WidthProvider} from 'react-grid-layout';
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
@@ -6,7 +7,7 @@ const ResponsiveReactGridLayout = WidthProvider(Responsive);
 class ShowcaseLayout extends React.Component {
 
   static propTypes = {
-    onLayoutChange: React.PropTypes.func.isRequired
+    onLayoutChange: PropTypes.func.isRequired
   };
 
   static defaultProps = {

--- a/test/examples/1-basic.jsx
+++ b/test/examples/1-basic.jsx
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
 var WidthProvider = require('react-grid-layout').WidthProvider;
@@ -11,7 +12,7 @@ var BasicLayout = React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
-    onLayoutChange: React.PropTypes.func.isRequired
+    onLayoutChange: PropTypes.func.isRequired
   },
 
   getDefaultProps() {

--- a/test/examples/11-no-vertical-compact.jsx
+++ b/test/examples/11-no-vertical-compact.jsx
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
 var WidthProvider = require('react-grid-layout').WidthProvider;
@@ -10,7 +11,7 @@ var NoCompactingLayout = React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
-    onLayoutChange: React.PropTypes.func.isRequired
+    onLayoutChange: PropTypes.func.isRequired
   },
 
   getDefaultProps() {

--- a/test/examples/2-no-dragging.jsx
+++ b/test/examples/2-no-dragging.jsx
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
 var WidthProvider = require('react-grid-layout').WidthProvider;
@@ -10,7 +11,7 @@ var NoDraggingLayout = React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
-    onLayoutChange: React.PropTypes.func.isRequired
+    onLayoutChange: PropTypes.func.isRequired
   },
 
   getDefaultProps() {

--- a/test/examples/3-messy.jsx
+++ b/test/examples/3-messy.jsx
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var _ = require('lodash');
 var WidthProvider = require('react-grid-layout').WidthProvider;
@@ -10,7 +11,7 @@ var MessyLayout = React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
-    onLayoutChange: React.PropTypes.func.isRequired
+    onLayoutChange: PropTypes.func.isRequired
   },
 
   getDefaultProps() {


### PR DESCRIPTION
Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.

## **HEY - Full disclaimer, I did not test this! :)**
I just found all the places I could find where PropTypes was being imported from react and changed it to use prop-types, and added the dependency of course.