### PR TITLE
Added isRearrangeable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ rowHeight: ?number = 150,
 //
 isDraggable: ?boolean = true,
 isResizable: ?boolean = true,
+// Enable or disable grid rearrangement when dragging/resizing an element.
+isRearrangeable: ?boolean = true,
 // Uses CSS3 translate() instead of position top/left.
 // This makes about 6x faster paint performance
 useCSSTransforms: ?boolean = true,

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,4 +1,4 @@
-import {bottom, collides, validateLayout} from '../lib/utils.js';
+import {bottom, collides, validateLayout, moveElement} from '../lib/utils.js';
 
 describe('bottom', () => {
   it('Handles an empty layout as input', () => {
@@ -43,5 +43,26 @@ describe('validateLayout', () => {
         {x: 1, y: 2, w: 1}
       ]);
     }).toThrowError('Layout[1].h must be a number!');
+  });
+});
+
+describe('moveElement', () => {
+  it('Does not change layout when colliding on no rearrangement mode', () => {
+    const layout = [{x: 0, y: 1, w: 1, h: 1, moved: false}, {x: 1, y: 2, w: 1, h: 1, moved: false}];
+    const layoutItem = layout[0];
+    expect(moveElement(
+      layout, layoutItem,
+      1, 2, // x, y
+      true, false // isUserAction, isRearrangeable
+    )).toEqual([{x: 0, y: 1, w: 1, h: 1, moved: false}, {x: 1, y: 2, w: 1, h: 1, moved: false}]);
+  });
+  it('Does change layout when colliding in rearrangement mode', () => {
+    const layout = [{x: 0, y: 0, w: 1, h: 1, moved: false}, {x: 1, y: 0, w: 1, h: 1, moved: false}];
+    const layoutItem = layout[0];
+    expect(moveElement(
+      layout, layoutItem,
+      1, 0, // x, y
+      true, true // isUserAction, isRearrangeable
+    )).toEqual([{x: 1, y: 0, w: 1, h: 1, moved: true}, {x: 1, y: 1, w: 1, h: 1, moved: true}]);
   });
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -217,11 +217,13 @@ export function getStatics(layout: Layout): Array<LayoutItem> {
  * @param  {Boolean}    [isUserAction] If true, designates that the item we're moving is
  *                                     being dragged/resized by the user.
  */
-export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?number, isUserAction: ?boolean): Layout {
+export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?number, isUserAction: ?boolean, isRearrangeable: ?boolean = true): Layout {
   if (l.static) return layout;
 
   // Short-circuit if nothing to do.
   if (l.y === y && l.x === x) return layout;
+
+  const old = {x: l.x, y: l.y};
 
   const movingUp = y && l.y > y;
   // This is quite a bit faster than extending the object
@@ -236,6 +238,14 @@ export function moveElement(layout: Layout, l: LayoutItem, x: ?number, y: ?numbe
   let sorted = sortLayoutItemsByRowCol(layout);
   if (movingUp) sorted = sorted.reverse();
   const collisions = getAllCollisions(sorted, l);
+
+  // Short circuit if there is a collision in no rearrangement mode.
+  if (!isRearrangeable && collisions.length !== 0) {
+    l.x = old.x;
+    l.y = old.y;
+    l.moved = false;
+    return layout;
+  }
 
   // Move each item that collides away from this element.
   for (let i = 0, len = collisions.length; i < len; i++) {


### PR DESCRIPTION
This option allows to prevent items to move away when dragging/resizing an element.
It simply add short circuit to `moveElement` and `onResize` when this option is enabled.

In combination with `verticalCompact={false}` and `maxRows` props, it allow me to build a dashboard with fixed height and width. `isRearrangeable` allows to bypass `maxRow` overflow when dragging and resizing elements since other elements can't be push to the bottom anymore.

Perhaps the prop name is not very good 🙂