### PR TITLE
add timeout hack; ref. https://stackoverflow.com/questions/26556436/r…

### DIFF
--- a/lib/components/WidthProvider.jsx
+++ b/lib/components/WidthProvider.jsx
@@ -43,7 +43,9 @@ const WidthProvider: ProviderT = (ComposedComponent) => class extends React.Comp
     // Call to properly set the breakpoint and resize the elements.
     // Note that if you're doing a full-width element, this can get a little wonky if a scrollbar
     // appears because of the grid. In that case, fire your own resize event, or set `overflow: scroll` on your body.
-    this.onWindowResize();
+    setTimeout(() => {
+        window.requestAnimationFrame(this.onWindowResize)
+    }, 0);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This temporary hack fixes a bug that appeared on Safari. 

Specifically, on Safari the stylesheet is rendered slower/later than componentDidMount method. Causing Safari to return incorrect offsetWidth if the parent uses CSS for styling (also see https://stackoverflow.com/questions/3702246/safari-is-returning-the-wrong-width-value)

The hack came from this SO post:  https://stackoverflow.com/questions/26556436/
