### PR TITLE
Export flow types

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -3,7 +3,7 @@
 import * as utils from './build/utils';
 export { default } from './build/ReactGridLayout';
 export { default as Responsive } from './build/ResponsiveReactGridLayout';
-export { default as WidthProvider } from './build/components/WidthProvider');
+export { default as WidthProvider } from './build/components/WidthProvider';
 
 export {
   utils

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,10 @@
+// @flow
+
+import * as utils from './build/utils';
+export { default } from './build/ReactGridLayout';
+export { default as Responsive } from './build/ResponsiveReactGridLayout';
+export { default as WidthProvider } from './build/components/WidthProvider');
+
+export {
+  utils
+};


### PR DESCRIPTION
Patching Responsive component with utils is not a good idea for es modules. Maybe better rename to `ResponsiveUtils`?