### PR TITLE
NULL option for compactType in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ draggableHandle: ?string = '',
 verticalCompact: ?boolean = true,
 
 // Compaction type.
-compactType: ?('vertical' | 'horizontal') = 'vertical';
+compactType: ?('vertical' | 'horizontal' | null) = 'vertical';
 
 // Layout is an array of object with the format:
 // {x: number, y: number, w: number, h: number}


### PR DESCRIPTION
**What's changed?**
Added 'null' option in list of values for `compactType` in Readme.md.

**Why?**
Right now if `verticalCompact` option is used while creating a new grid, following warning is printed in console:
```
verticalCompact` on <ReactGridLayout> is deprecated and will be removed soon.
Use `compactType`: "horizontal" | "vertical" | null.
```