### PR TITLE
use babel-present-env over es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["es2015", {"loose": true}],
+    ["env", {"loose": true}],
     "stage-1",
     "react"
   ],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
     "babel-plugin-typecheck": "^3.6.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "css-loader": "^0.28.9",


### PR DESCRIPTION
This removes es2015 warnings that come upon installing RGL