### PR TITLE
Fix unexpected behavior with verticalCompact enabled in version 16.02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 npm-debug.log
 build/
 .idea
+.vscode

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -445,6 +445,8 @@ export function moveElementAwayFromCollision(
   // We only do this on the main collision as this can get funky in cascades and cause
   // unwanted swapping behavior.
   if (isUserAction) {
+    // Reset isUserAction flag because we're not in the main collision more.
+    isUserAction = false;
     // Make a mock item so we don't modify the item here, only modify in moveElement.
     const fakeItem: LayoutItem = {
       x: compactH ? Math.max(collidesWith.x - itemToMove.w, 0) : itemToMove.x,

--- a/test/spec/utils-test.js
+++ b/test/spec/utils-test.js
@@ -265,6 +265,36 @@ describe("moveElement", () => {
       ]
     );
   });
+
+  it("Moves one element to another should cause moving down panels below when compaction is vertical", () => {
+    const layout = [
+      { x: 0, y: 0, w: 2, h: 1, i: "A" },
+      { x: 2, y: 0, w: 2, h: 1, i: "B" },
+      { x: 0, y: 1, w: 1, h: 1, i: "C" },
+      { x: 1, y: 1, w: 3, h: 1, i: "D" }
+    ];
+    // move B left slightly so it collides with A; can cause C to jump above A
+    // this test will check that that does not happen
+    const itemB = layout[1];
+    assert.deepEqual(
+      moveElement(
+        layout,
+        itemB,
+        1,
+        0, // x, y
+        true,
+        false, // isUserAction, preventCollision
+        "vertical",
+        4 // compactType, cols
+      ),
+      [
+        { x: 0, y: 1, w: 2, h: 1, i: "A", moved: true },
+        { x: 1, y: 0, w: 2, h: 1, i: "B", moved: true },
+        { x: 0, y: 2, w: 1, h: 1, i: "C", moved: true },
+        { x: 1, y: 2, w: 3, h: 1, i: "D", moved: true }
+      ]
+    );
+  });
 });
 
 describe("compact vertical", () => {


### PR DESCRIPTION
This PR fixes #714 
The root cause of this is `isUserAction` flag in `moveElementAwayFromCollision()` function. As described in comments:
>If there is enough space above the collision to put this element, move it there.
**We only do this on the main collision** as this can get funky in cascades and cause
unwanted swapping behavior.

But `isUserAction` is always `true`, not only in the main collision, so we should reset it after the first call.
I added a test case for this, it represents layout similar to one described in issue.