### PR TITLE
Fix for bugs when no compaction is on. 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,7 +122,7 @@ export function childrenEqual(a: ReactChildren, b: ReactChildren): boolean {
  * Given two layoutitems, check if they collide.
  */
 export function collides(l1: LayoutItem, l2: LayoutItem): boolean {
-  if (l1 === l2) return false; // same element
+  if (l1.i === l2.i) return false; // same element
   if (l1.x + l1.w <= l2.x) return false; // l1 is left of l2
   if (l1.x >= l2.x + l2.w) return false; // l1 is right of l2
   if (l1.y + l1.h <= l2.y) return false; // l1 is above l2
@@ -185,7 +185,11 @@ function resolveCompactionCollision(
 ) {
   const sizeProp = heightWidth[axis];
   item[axis] += 1;
-  const itemIndex = layout.indexOf(item);
+  const itemIndex = layout
+    .map(layoutItem => {
+      return layoutItem.i;
+    })
+    .indexOf(item.i);
 
   // Go through each item we collide with.
   for (let i = itemIndex + 1; i < layout.length; i++) {
@@ -441,7 +445,8 @@ export function moveElementAwayFromCollision(
   cols: number
 ): Layout {
   const compactH = compactType === "horizontal";
-  const compactV = compactType === "vertical";
+  // Compact vertically if not set to horizontal
+  const compactV = compactType !== "horizontal";
   const preventCollision = false; // we're already colliding
 
   // If there is enough space above the collision to put this element, move it there.


### PR DESCRIPTION
Both of these fixes are for when there is no compaction. See https://github.com/STRML/react-grid-layout/issues/750

For `moveElementAwayFromCollision()`, the issue is that if there is no compaction, `compactH` and `compactV` are both false, and no collision is resolved at all. The solution to this is to apply the vertical collision logic if `compactH` is not true ie. in all other instances. This is valid as there are other instances in the code that make the same assumption.

For  `resolveCompactionCollision()`, the code was detecting an item's collision with itself, thus moving everything down too far. This isn't a noticable problem when there is compaction, as it will resolve all the items moving down too far afterwards by compacting them back up, but the logic is still incorrect. When compaction is off though, the tiles get pushed down too far and remain there, leaving empty blank space.

Thanks!
Brian