### PR TITLE
add a new callback onInit to responsive RGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,10 @@ onBreakpointChange: (newBreakpoint: string, newCols: number) => void,
 onLayoutChange: (currentLayout: Layout, allLayouts: {[key: $Keys<breakpoints>]: Layout}) => void,
 
 // Callback when the width changes, so you can modify the layout as needed.
-onWidthChange: (containerWidth: number, margin: [number, number], cols: number, containerPadding: [number, number]) => void;
+onWidthChange: (containerWidth: number, margin: [number, number], cols: number, containerPadding: [number, number]) => void,
+
+// Callback when the initial state has been set
+onInit: State => void;
 
 ```
 

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -23,7 +23,8 @@ const type = obj => Object.prototype.toString.call(obj);
 type State = {
   layout: Layout,
   breakpoint: string,
-  cols: number
+  cols: number,
+  width: number
 };
 
 type Props<Breakpoint: string = string> = {
@@ -44,7 +45,8 @@ type Props<Breakpoint: string = string> = {
     margin: [number, number],
     cols: number,
     containerPadding: [number, number] | null
-  ) => void
+  ) => void,
+  onInit: State => void
 };
 
 export default class ResponsiveReactGridLayout extends React.Component<
@@ -103,7 +105,10 @@ export default class ResponsiveReactGridLayout extends React.Component<
     onLayoutChange: PropTypes.func,
 
     // Calls back with (containerWidth, margin, cols, containerPadding)
-    onWidthChange: PropTypes.func
+	onWidthChange: PropTypes.func,
+
+	// Calls back at the end of generateInitalState() with the initial state
+	onInit: PropTypes.func
   };
 
   static defaultProps = {
@@ -112,7 +117,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
     layouts: {},
     onBreakpointChange: noop,
     onLayoutChange: noop,
-    onWidthChange: noop
+	onWidthChange: noop,
+	onInit: noop
   };
 
   state = this.generateInitialState();
@@ -133,13 +139,16 @@ export default class ResponsiveReactGridLayout extends React.Component<
       breakpoint,
       colNo,
       compactType
-    );
-
-    return {
-      layout: initialLayout,
-      breakpoint: breakpoint,
-      cols: colNo
-    };
+	);
+	const initState: State = {
+		layout: initialLayout,
+		breakpoint: breakpoint,
+		cols: colNo,
+		width: width
+	};
+	// Callback onInit
+	this.props.onInit(initState);
+    return initState
   }
 
   componentWillReceiveProps(nextProps: Props<*>) {
@@ -249,7 +258,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
       layouts,
       onBreakpointChange,
       onLayoutChange,
-      onWidthChange,
+	  onWidthChange,
+	  onInit,
       ...other
     } = this.props;
     /* eslint-enable no-unused-vars */


### PR DESCRIPTION
This callback is called in the end of `generateInitialState()` in `ResponsiveReactGridLayout.` It can be used to trigger actions upon the initial loading of the user-defined component, that can make use of the initial state of `ResponsiveReactGridLayout`.
I.e. I'm using this to calculate the `rowHeight` based on the component's width and the number of cols to create square shaped grid cells.


