### PR TITLE
add missing demo links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ RGL is React-only and does not require jQuery.
 1. [Minimum and Maximum Width/Height](https://strml.github.io/react-grid-layout/examples/9-min-max-wh.html)
 1. [Dynamic Minimum and Maximum Width/Height](https://strml.github.io/react-grid-layout/examples/10-dynamic-min-max-wh.html)
 1. [No Vertical Compacting (Free Movement)](https://strml.github.io/react-grid-layout/examples/11-no-vertical-compact.html)
+1. [Prevent Collision](https://strml.github.io/react-grid-layout/examples/12-prevent-collision.html)
+1. [Error Case](https://strml.github.io/react-grid-layout/examples/13-error-case.html)
+1. [Toolbox](https://strml.github.io/react-grid-layout/examples/14-toolbox.html)
+
 
 #### Projects Using React-Grid-Layout
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ RGL is React-only and does not require jQuery.
 1. [Error Case](https://strml.github.io/react-grid-layout/examples/13-error-case.html)
 1. [Toolbox](https://strml.github.io/react-grid-layout/examples/14-toolbox.html)
 
-
 #### Projects Using React-Grid-Layout
 
 - [BitMEX](https://www.bitmex.com/)


### PR DESCRIPTION
Hi there, noticed that the last three demos are not currently linked in the README; this adds links for them.  NOTE: this isn't ready to merge as is, because the toolbox demo appears to be not hosted on the github site currently. What would be required to fix that? (https://strml.github.io/react-grid-layout/examples/14-toolbox.html results in a 404, issue #820)
