### PR TITLE
Don't collide statics with non-statics

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -270,7 +270,8 @@ export function correctBounds(
   layout: Layout,
   bounds: { cols: number }
 ): Layout {
-  const collidesWith = getStatics(layout);
+  const collidesWithStatics = getStatics(layout);
+  const collidesWith = [];
   for (let i = 0, len = layout.length; i < len; i++) {
     const l = layout[i];
     // Overflows right
@@ -283,9 +284,14 @@ export function correctBounds(
     if (l.static) {
       // If this is static and collides with other statics, we must move it down.
       // We have to do something nicer than just letting them overlap.
+      while (getFirstCollision(collidesWithStatics, l)) {
+        l.y++;
+      }
+    } else {
       while (getFirstCollision(collidesWith, l)) {
         l.y++;
       }
+      collidesWith.push(l);
     }
   }
   return layout;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -280,8 +280,7 @@ export function correctBounds(
       l.x = 0;
       l.w = bounds.cols;
     }
-    if (!l.static) collidesWith.push(l);
-    else {
+    if (l.static) {
       // If this is static and collides with other statics, we must move it down.
       // We have to do something nicer than just letting them overlap.
       while (getFirstCollision(collidesWith, l)) {


### PR DESCRIPTION
Otherwise static elements change position due to non-statics.

correctBounds is called just before a compaction pass, so this should not cause other issues.

Fixes #825