### PR TITLE
Add graphext to projects using react-grid-layout list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ RGL is React-only and does not require jQuery.
 - [Reflect](https://reflect.io)
 - [ez-Dashing](https://github.com/ylacaute/ez-Dashing)
 - [Kibana](https://www.elastic.co/products/kibana)
+- [Graphext](https://graphext.com/)
 
 *Know of others? Create a PR to let me know!*
 


### PR DESCRIPTION
Hi, I am a developer at [Graphext](https://graphext.com/).
Since a few months ago we are using this library in one of the core parts of our product, and it would be a pleasure for us to appear in the README list as company using this library 👍 .
We are very proud of being using `react-grid-layout` as we have benefited a lot from this.

Thank you very much for creating and maintaining this project.
