### PR TITLE
Invoking onLayoutChange only when item was moved or resized

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -412,7 +412,6 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     // Set state
     const newLayout = compact(layout, this.compactType(), cols);
-    const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,
       layout: newLayout,
@@ -420,7 +419,9 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       oldLayout: null
     });
 
-    this.onLayoutMaybeChanged(newLayout, oldLayout);
+    if(!isEqual(oldDragItem, l)) {
+      this.props.onLayoutChange(newLayout);
+    }
   }
 
   onLayoutMaybeChanged(newLayout: Layout, oldLayout: ?Layout) {
@@ -507,7 +508,6 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     // Set state
     const newLayout = compact(layout, this.compactType(), cols);
-    const { oldLayout } = this.state;
     this.setState({
       activeDrag: null,
       layout: newLayout,
@@ -515,7 +515,9 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       oldLayout: null
     });
 
-    this.onLayoutMaybeChanged(newLayout, oldLayout);
+    if(!isEqual(oldDragItem, l)) {
+      this.props.onLayoutChange(newLayout);
+    }
   }
 
   /**


### PR DESCRIPTION
#504 

When clicking a draggable item or when clicking the resize handle on resizable items the onLayoutChange was invoked, presumably because `isEqual(oldLayout, newLayout)` returns `true`. 
I did not investigate why exactly this happens, but regardless I belive the following solution is better, as it doesn't require a deep comparison of oldLayout and newLayout. 

In the event-handler for onDragStop and onResizeStop I'm making the assumption that if `isEqual(oldDragItem, l)` (ie oldItem is the same as newItem) then the layout has **not** changed, and we don't need to invoke `onLayoutMaybeChanged` method. 

If they are not equal however, then the layout must have changed, and we can invoke `this.props.onLayoutChange` directly with `newLayout`. 