### PR TITLE
Added support for dragging from external sources

### DIFF
--- a/examples/0-showcase.html
+++ b/examples/0-showcase.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/0-showcase.bundle.js"></script>
     <title>RGL Example 0 - Showcase</title>
   </head>

--- a/examples/1-basic.html
+++ b/examples/1-basic.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/1-basic.bundle.js"></script>
     <title>RGL Example 1 - Basic</title>
   </head>

--- a/examples/10-dynamic-min-max-wh.html
+++ b/examples/10-dynamic-min-max-wh.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/10-dynamic-min-max-wh.bundle.js"></script>
     <title>RGL Example 10 - Dynamic Minimum and Maximum Width/Height</title>
   </head>

--- a/examples/11-no-vertical-compact.html
+++ b/examples/11-no-vertical-compact.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/11-no-vertical-compact.bundle.js"></script>
     <title>RGL Example 11 - No Vertical Compacting (Free Movement)</title>
   </head>

--- a/examples/12-prevent-collision.html
+++ b/examples/12-prevent-collision.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/12-prevent-collision.bundle.js"></script>
     <title>RGL Example 12 - Prevent Collision</title>
   </head>

--- a/examples/13-error-case.html
+++ b/examples/13-error-case.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/13-error-case.bundle.js"></script>
     <title>RGL Example 13 - Error Case</title>
   </head>

--- a/examples/14-toolbox.html
+++ b/examples/14-toolbox.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/14-toolbox.bundle.js"></script>
     <title>RGL Example 14 - Toolbox</title>
   </head>

--- a/examples/2-no-dragging.html
+++ b/examples/2-no-dragging.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/2-no-dragging.bundle.js"></script>
     <title>RGL Example 2 - No Dragging</title>
   </head>

--- a/examples/3-messy.html
+++ b/examples/3-messy.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/3-messy.bundle.js"></script>
     <title>RGL Example 3 - Messy</title>
   </head>

--- a/examples/4-grid-property.html
+++ b/examples/4-grid-property.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/4-grid-property.bundle.js"></script>
     <title>RGL Example 4 - Grid Item Properties</title>
   </head>

--- a/examples/5-static-elements.html
+++ b/examples/5-static-elements.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/5-static-elements.bundle.js"></script>
     <title>RGL Example 5 - Static Elements</title>
   </head>

--- a/examples/6-dynamic-add-remove.html
+++ b/examples/6-dynamic-add-remove.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/6-dynamic-add-remove.bundle.js"></script>
     <title>RGL Example 6 - Dynamic Add/Remove</title>
   </head>

--- a/examples/7-localstorage.html
+++ b/examples/7-localstorage.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/7-localstorage.bundle.js"></script>
     <title>RGL Example 7 - LocalStorage</title>
   </head>

--- a/examples/8-localstorage-responsive.html
+++ b/examples/8-localstorage-responsive.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/8-localstorage-responsive.bundle.js"></script>
     <title>RGL Example 8 - Responsive with LocalStorage</title>
   </head>

--- a/examples/9-min-max-wh.html
+++ b/examples/9-min-max-wh.html
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="http://localhost:4002/dist/commons.js"></script>
+    <script src="http://localhost:4002/dist/commons.bundle.js"></script>
     <script src="http://localhost:4002/dist/9-min-max-wh.bundle.js"></script>
     <title>RGL Example 9 - Minimum and Maximum Width/Height</title>
   </head>

--- a/examples/example-styles.css
+++ b/examples/example-styles.css
@@ -85,6 +85,7 @@ li b {
 }
 .toolbox__items__item {
   display: inline-block;
+  z-index: 2;
   text-align: center;
   line-height: 40px;
   cursor: pointer;
@@ -94,4 +95,7 @@ li b {
   margin: 5px;
   border: 1px solid black;
   background-color: #ddd;
+}
+.toolbox__items__item.react-draggable-dragging {
+  position: absolute;
 }

--- a/examples/template.ejs
+++ b/examples/template.ejs
@@ -5,7 +5,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="<%= base %>/dist/commons.js"></script>
+    <script src="<%= base %>/dist/commons.bundle.js"></script>
     <script src="<%= base %>/dist/<%= index %>-<%= source %>.bundle.js"></script>
     <title>RGL Example <%= index %> - <%= title %></title>
   </head>

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -342,12 +342,24 @@ export default class ReactGridLayout extends React.Component<Props, State> {
    * @param {Event} e The mousedown event
    * @param {Element} node The current dragging DOM element
    */
-  onDrag(i: string, x: number, y: number, { e, node }: GridDragEvent) {
+  onDrag(
+    i: string,
+    x: number,
+    y: number,
+    { e, node, newPosition, animatePlaceholder }: GridDragEvent
+  ) {
     const { oldDragItem } = this.state;
     let { layout } = this.state;
     const { cols } = this.props;
     var l = getLayoutItem(layout, i);
     if (!l) return;
+
+    let showPlaceholder;
+    if (typeof animatePlaceholder != "undefined" && !animatePlaceholder) {
+      showPlaceholder = false;
+    } else {
+      showPlaceholder = true;
+    }
 
     // Create placeholder (display only)
     var placeholder = {
@@ -356,6 +368,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       x: l.x,
       y: l.y,
       placeholder: true,
+      animatePlaceholder: animatePlaceholder,
       i: i
     };
 
@@ -376,7 +389,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.setState({
       layout: compact(layout, this.compactType(), cols),
-      activeDrag: placeholder
+      activeDrag: placeholder,
+      showPlaceholder: showPlaceholder
     });
   }
 
@@ -535,6 +549,10 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       useCSSTransforms
     } = this.props;
 
+    if (!this.state.showPlaceholder) {
+      return null;
+    }
+
     // {...this.state.activeDrag} is pretty slow, actually
     return (
       <GridItem
@@ -611,6 +629,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         isResizable={resizable}
         useCSSTransforms={useCSSTransforms && mounted}
         usePercentages={!mounted}
+        continueDrag={l.continueDrag}
         w={l.w}
         h={l.h}
         x={l.x}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,8 @@ export type LayoutItem = {
   moved?: boolean,
   static?: boolean,
   isDraggable?: ?boolean,
-  isResizable?: ?boolean
+  isResizable?: ?boolean,
+  continueDrag?: ?boolean
 };
 export type Layout = Array<LayoutItem>;
 export type Position = {
@@ -103,7 +104,8 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
     static: Boolean(layoutItem.static),
     // These can be null
     isDraggable: layoutItem.isDraggable,
-    isResizable: layoutItem.isResizable
+    isResizable: layoutItem.isResizable,
+    continueDrag: layoutItem.continueDrag
   };
 }
 
@@ -199,7 +201,7 @@ function resolveCompactionCollision(
 
     // Optimization: we can break early if we know we're past this el
     // We can do this b/c it's a sorted layout
-    if (otherItem.y > (item.y + item.h)) break;
+    if (otherItem.y > item.y + item.h) break;
 
     if (collides(item, otherItem)) {
       resolveCompactionCollision(
@@ -354,20 +356,22 @@ export function moveElement(
   isUserAction: ?boolean,
   preventCollision: ?boolean,
   compactType: CompactType,
-  cols: number,
+  cols: number
 ): Layout {
   if (l.static) return layout;
 
   // Short-circuit if nothing to do.
   if (l.y === y && l.x === x) return layout;
 
-  log(`Moving element ${l.i} to [${String(x)},${String(y)}] from [${l.x},${l.y}]`);
+  log(
+    `Moving element ${l.i} to [${String(x)},${String(y)}] from [${l.x},${l.y}]`
+  );
   const oldX = l.x;
   const oldY = l.y;
 
   // This is quite a bit faster than extending the object
-  if (typeof x === 'number') l.x = x;
-  if (typeof y === 'number') l.y = y;
+  if (typeof x === "number") l.x = x;
+  if (typeof y === "number") l.y = y;
   l.moved = true;
 
   // If this collides with anything, move it.
@@ -376,9 +380,11 @@ export function moveElement(
   // nearest collision.
   let sorted = sortLayoutItems(layout, compactType);
   const movingUp =
-    compactType === "vertical" && typeof y === 'number' ? oldY >= y
-    : compactType === "horizontal" && typeof x === 'number' ? oldX >= x
-    : false;
+    compactType === "vertical" && typeof y === "number"
+      ? oldY >= y
+      : compactType === "horizontal" && typeof x === "number"
+      ? oldX >= x
+      : false;
   if (movingUp) sorted = sorted.reverse();
   const collisions = getAllCollisions(sorted, l);
 


### PR DESCRIPTION
Adds support for dragging elements from external sources to support #842 
As a showcase, the toolbox example has been updated to drag items back on the grid 

Fixes the path to commons bundle same as #937 