### PR TITLE
changed readme accordingly to responsive mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ If the largest is provided, RGL will attempt to interpolate the rest.
 You will also need to provide a `width`, when using `<ResponsiveReactGridLayout>` it is suggested you use the HOC
 `WidthProvider` as per the instructions below.
 
-For the time being, it is not possible to supply responsive mappings via the `data-grid` property on individual
-items, but that is coming soon.
+It is possible to supply default mappings via the `data-grid` property on individual
+items, so that they would be taken into account within layout interpolation. 
 
 ### Providing Grid Width
 


### PR DESCRIPTION
Readme is a bit confusing, because accordingly to [example](https://github.com/STRML/react-grid-layout/blob/3352c84515e587c2bb7ec7935e24be5705d33704/test/examples/8-localstorage-responsive.jsx#L49) it's possible to use `data-grid` props to set default mappings for individual items