### PR TITLE
Ability to store data on layout items

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,6 +102,7 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
     moved: Boolean(layoutItem.moved),
     static: Boolean(layoutItem.static),
     // These can be null
+    data: layoutItem.data,
     isDraggable: layoutItem.isDraggable,
     isResizable: layoutItem.isResizable
   };


### PR DESCRIPTION
I had a use case where I needed to attach certain data to each grid item. The issue is that custom data points disappear after every layout change (happens in `utils.js/cloneLayoutItem`). I added a special data point, `data`, which will be preserved.