### PR TITLE
fixed RangeError: Maximum call stack size exceeded.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -406,9 +406,7 @@ export function moveElement(
   for (let i = 0, len = collisions.length; i < len; i++) {
     const collision = collisions[i];
     log(
-      `Resolving collision between ${l.i} at [${l.x},${l.y}] and ${
-        collision.i
-      } at [${collision.x},${collision.y}]`
+      `Resolving collision between ${l.i} at [${l.x},${l.y}] and ${collision.i} at [${collision.x},${collision.y}]`
     );
 
     // Short circuit so we can't infinite loop
@@ -458,7 +456,7 @@ export function moveElementAwayFromCollision(
   const compactH = compactType === "horizontal";
   // Compact vertically if not set to horizontal
   const compactV = compactType !== "horizontal";
-  const preventCollision = false; // we're already colliding
+  const preventCollision = collidesWith.static; // we're already colliding (not for static items)
 
   // If there is enough space above the collision to put this element, move it there.
   // We only do this on the main collision as this can get funky in cascades and cause
@@ -479,9 +477,7 @@ export function moveElementAwayFromCollision(
     // No collision? If so, we can go up there; otherwise, we'll end up moving down as normal
     if (!getFirstCollision(layout, fakeItem)) {
       log(
-        `Doing reverse collision on ${itemToMove.i} up to [${fakeItem.x},${
-          fakeItem.y
-        }].`
+        `Doing reverse collision on ${itemToMove.i} up to [${fakeItem.x},${fakeItem.y}].`
       );
       return moveElement(
         layout,


### PR DESCRIPTION
Fixed RangeError: Maximum call stack size exceeded when dragging an element over a static element causes.

The point of the solution is that when we drag an element over a static one, a collision occurs and we have to interrupt the operation.

Fixes #941 