### PR TITLE
chore(actions): increase operations count and runs frequency

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: "Close stale issues and PRs"
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 0,6,12,18 * * *"
 
 jobs:
   stale:
@@ -16,3 +16,4 @@ jobs:
         exempt-pr-label: 'stale'
         days-before-stale: 30
         days-before-close: 7
+        operations-per-run: 50 


### PR DESCRIPTION
unfortunately, stale action can't check all PRs and issues per one single run. Now we want to check about 300 issues, but we can't do 300+ requests per run because of GH's rate limits (as far as I know), that's why we should do those requests partially. 

So I increased operations count and runs frequency to check 50 issues and PRs every 6 hours. 

It'll help us to check almost all issues per day