### PR TITLE
Fix overriding global options for dragging and resizing grid item

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "lodash.isequal";
+import isNil from "lodash.isnil";
 import classNames from "classnames";
 import {
   autoBindHandlers,
@@ -660,10 +661,10 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     // Parse 'static'. Any properties defined directly on the grid item will take precedence.
     const draggable = Boolean(
-      !l.static && isDraggable && (l.isDraggable || l.isDraggable == null)
+      l.static ? !l.static : !isNil(l.isDraggable) ? l.isDraggable : isDraggable
     );
     const resizable = Boolean(
-      !l.static && isResizable && (l.isResizable || l.isResizable == null)
+      l.static ? !l.static : !isNil(l.isResizable) ? l.isResizable : isResizable
     );
 
     return (

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import isEqual from "lodash.isequal";
-import isNil from "lodash.isnil";
 import classNames from "classnames";
 import {
   autoBindHandlers,
@@ -661,10 +660,18 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     // Parse 'static'. Any properties defined directly on the grid item will take precedence.
     const draggable = Boolean(
-      l.static ? !l.static : !isNil(l.isDraggable) ? l.isDraggable : isDraggable
+      l.static
+        ? !l.static
+        : l.isDraggable === null || l.isDraggable === undefined
+        ? isDraggable
+        : l.isDraggable
     );
     const resizable = Boolean(
-      l.static ? !l.static : !isNil(l.isResizable) ? l.isResizable : isResizable
+      l.static
+        ? !l.static
+        : l.isResizable === null || l.isResizable === undefined
+        ? isResizable
+        : l.isResizable
     );
 
     return (

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "classnames": "2.x",
     "lodash.isequal": "^4.0.0",
+    "lodash.isnil": "^4.0.0",
     "prop-types": "^15.0.0",
     "react-draggable": "^4.0.0",
     "react-resizable": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "classnames": "2.x",
     "lodash.isequal": "^4.0.0",
-    "lodash.isnil": "^4.0.0",
     "prop-types": "^15.0.0",
     "react-draggable": "^4.0.0",
     "react-resizable": "^1.0.0"


### PR DESCRIPTION
It resolves [#478 ](https://github.com/STRML/react-grid-layout/issues/478) and allows local options to override global ones for resizing and dragging grid item