### PR TITLE
Resizable handles on other corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ containerPadding: ?[number, number] = margin,
 // if you like.
 rowHeight: ?number = 150,
 
-// Configuration of a dropping element. Dropping element is a "virtual" element 
+// Configuration of a dropping element. Dropping element is a "virtual" element
 // which appears when you drag over some element from outside.
 // It can be changed by passing specific parameters:
 //  i - id of an element
@@ -311,9 +311,9 @@ transformScale: ?number = 1,
 // dragged over.
 preventCollision: ?boolean = false;
 
-// If true, droppable elements (with `draggable={true}` attribute) 
+// If true, droppable elements (with `draggable={true}` attribute)
 // can be dropped on the grid. It triggers "onDrop" callback
-// with position and event object as parameters. 
+// with position and event object as parameters.
 // It can be useful for dropping an element in a specific position
 //
 // NOTE: In case of using Firefox you should add
@@ -322,6 +322,17 @@ preventCollision: ?boolean = false;
 // onDragStart attribute is required for Firefox for a dragging initialization
 // @see https://bugzilla.mozilla.org/show_bug.cgi?id=568313
 isDroppable: ?boolean = false
+// Defines which resize handles should be rendered
+// Allows for any combination of:
+// 's' - South handle (bottom-center)
+// 'w' - West handle (left-center)
+// 'e' - East handle (right-center)
+// 'n' - North handle (top-center)
+// 'sw' - Southwest handle (bottom-left)
+// 'nw' - Northwest handle (top-left)
+// 'se' - Southeast handle (bottom-right)
+// 'ne' - Northeast handle (top-center)
+resizeHandles: ?string[] = ['se']
 
 //
 // Callbacks
@@ -437,6 +448,7 @@ will be draggable.
   isDraggable: ?boolean = true,
   // If false, will not be resizable. Overrides `static`.
   isResizable: ?boolean = true
+  resizeHandles?: ?Array<'s' | 'w' | 'e' | 'n' | 'sw' | 'nw' | 'se' | 'ne'> = ['se']
 }
 ```
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -42,7 +42,6 @@
   height: 20px;
   bottom: 0;
   right: 0;
-  cursor: se-resize;
 }
 
 .react-grid-item > .react-resizable-handle::after {
@@ -54,4 +53,8 @@
   height: 5px;
   border-right: 2px solid rgba(0, 0, 0, 0.4);
   border-bottom: 2px solid rgba(0, 0, 0, 0.4);
+}
+
+.react-resizable-handle {
+  cursor: se-resize;
 }

--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -63,6 +63,8 @@ type Props = {
   maxH: number,
   i: string,
 
+  resizeHandles?: string[],
+
   onDrag?: GridItemCallback<GridDragEvent>,
   onDragStart?: GridItemCallback<GridDragEvent>,
   onDragStop?: GridItemCallback<GridDragEvent>,
@@ -390,7 +392,7 @@ export default class GridItem extends React.Component<Props, State> {
     child: ReactElement<any>,
     position: Position
   ): ReactElement<any> {
-    const { cols, x, minW, minH, maxW, maxH } = this.props;
+    const { cols, x, minW, minH, maxW, maxH, resizeHandles } = this.props;
 
     // This is the max possible width - doesn't go to infinity because of the width of the window
     const maxWidth = this.calcPosition(0, 0, cols - x, 0).width;
@@ -412,6 +414,7 @@ export default class GridItem extends React.Component<Props, State> {
         onResizeStop={this.onResizeStop}
         onResizeStart={this.onResizeStart}
         onResize={this.onResize}
+        resizeHandles={resizeHandles}
       >
         {child}
       </Resizable>

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -71,6 +71,7 @@ export type Props = {
   useCSSTransforms: boolean,
   transformScale: number,
   droppingItem: $Shape<LayoutItem>,
+  resizeHandles: string[],
 
   // Callbacks
   onLayoutChange: Layout => void,
@@ -184,6 +185,19 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     transformScale: PropTypes.number,
     // If true, an external element can trigger onDrop callback with a specific grid position as a parameter
     isDroppable: PropTypes.bool,
+    // Defines which resize handles should be rendered (default: 'se')
+    // Allows for any combination of:
+    // 's' - South handle (bottom-center)
+    // 'w' - West handle (left-center)
+    // 'e' - East handle (right-center)
+    // 'n' - North handle (top-center)
+    // 'sw' - Southwest handle (bottom-left)
+    // 'nw' - Northwest handle (top-left)
+    // 'se' - Southeast handle (bottom-right)
+    // 'ne' - Northeast handle (top-center)
+    resizeHandles: PropTypes.arrayOf(
+      PropTypes.oneOf(["s", "w", "e", "n", "sw", "nw", "se", "ne"])
+    ),
 
     //
     // Callbacks
@@ -262,6 +276,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       h: 1,
       w: 1
     },
+    resizeHandles: ["se"],
     onLayoutChange: noop,
     onDragStart: noop,
     onDrag: noop,
@@ -654,7 +669,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       useCSSTransforms,
       transformScale,
       draggableCancel,
-      draggableHandle
+      draggableHandle,
+      resizeHandles
     } = this.props;
     const { mounted, droppingPosition } = this.state;
 
@@ -665,6 +681,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     const resizable = Boolean(
       !l.static && isResizable && (l.isResizable || l.isResizable == null)
     );
+    const resizeHandlesOptions = l.resizeHandles || resizeHandles;
 
     return (
       <GridItem
@@ -698,6 +715,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         maxW={l.maxW}
         static={l.static}
         droppingPosition={isDroppingItem ? droppingPosition : undefined}
+        resizeHandles={resizeHandlesOptions}
       >
         {child}
       </GridItem>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,8 @@ export type LayoutItem = {
   moved?: boolean,
   static?: boolean,
   isDraggable?: ?boolean,
-  isResizable?: ?boolean
+  isResizable?: ?boolean,
+  resizeHandles?: string[]
 };
 export type Layout = Array<LayoutItem>;
 export type Position = {
@@ -113,7 +114,8 @@ export function cloneLayoutItem(layoutItem: LayoutItem): LayoutItem {
     static: Boolean(layoutItem.static),
     // These can be null
     isDraggable: layoutItem.isDraggable,
-    isResizable: layoutItem.isResizable
+    isResizable: layoutItem.isResizable,
+    resizeHandles: layoutItem.resizeHandles
   };
 }
 


### PR DESCRIPTION
It implements [#758 ](https://github.com/STRML/react-grid-layout/issues/758), allows resizable handles on other corner. It passes `resizeHandles` props to [react-resizable](https://github.com/STRML/react-resizable)