### PR TITLE
Protect from non-existent or bad implementations of `navigator`

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -97,7 +97,13 @@ const compactType = (props: Props): CompactType => {
 };
 
 const layoutClassName = "react-grid-layout";
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+let isFirefox = false;
+// Try...catch will protect from navigator not existing (e.g. node) or a bad implementation of navigator
+try {
+  isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+} catch (e) {
+  /* Ignore */
+}
 
 /**
  * A reactive, fluid grid layout with draggable, resizable components.


### PR DESCRIPTION
This was an issue for my usage as the package is imported in a node context, and this navigator check is done at the top level of this package, rather than after rendering the grid. So window is undefined at the point that it is included initially. 

This fixes the issue I created here: https://github.com/STRML/react-grid-layout/issues/1056