### PR TITLE
fix(GridItem): ensure locally set isDraggable/isResizable overrides globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ containerPadding: ?[number, number] = margin,
 // if you like.
 rowHeight: ?number = 150,
 
-// Configuration of a dropping element. Dropping element is a "virtual" element 
+// Configuration of a dropping element. Dropping element is a "virtual" element
 // which appears when you drag over some element from outside.
 // It can be changed by passing specific parameters:
 //  i - id of an element
@@ -311,9 +311,9 @@ transformScale: ?number = 1,
 // dragged over.
 preventCollision: ?boolean = false;
 
-// If true, droppable elements (with `draggable={true}` attribute) 
+// If true, droppable elements (with `draggable={true}` attribute)
 // can be dropped on the grid. It triggers "onDrop" callback
-// with position and event object as parameters. 
+// with position and event object as parameters.
 // It can be useful for dropping an element in a specific position
 //
 // NOTE: In case of using Firefox you should add
@@ -413,7 +413,7 @@ are out of range.
 
 Any `<GridItem>` properties defined directly will take precedence over globally-set options. For
 example, if the layout has the property `isDraggable: false`, but the grid item has the prop `isDraggable: true`, the item
-will be draggable.
+will be draggable, even if the item is marked `static: true`.
 
 ```js
 {

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -664,13 +664,17 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     } = this.props;
     const { mounted, droppingPosition } = this.state;
 
-    // Parse 'static'. Any properties defined directly on the grid item will take precedence.
-    const draggable = Boolean(
-      !l.static && isDraggable && (l.isDraggable || l.isDraggable == null)
-    );
-    const resizable = Boolean(
-      !l.static && isResizable && (l.isResizable || l.isResizable == null)
-    );
+    // Determine user manipulations possible.
+    // If an item is static, it can't be manipulated by default.
+    // Any properties defined directly on the grid item will take precedence.
+    const draggable =
+      typeof l.isDraggable === "boolean"
+        ? l.isDraggable
+        : !l.static && isDraggable;
+    const resizable =
+      typeof l.isResizable === "boolean"
+        ? l.isResizable
+        : !l.static && isResizable;
 
     return (
       <GridItem

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -366,7 +366,9 @@ export function moveElement(
   compactType: CompactType,
   cols: number
 ): Layout {
-  if (l.static) return layout;
+  // If this is static and not explicitly enabled as draggable,
+  // no move is possible, so we can short-circuit this immediately.
+  if (l.static && l.isDraggable !== true) return layout;
 
   // Short-circuit if nothing to do.
   if (l.y === y && l.x === x) return layout;


### PR DESCRIPTION
This also makes static items resizable/draggable if locally set, which is
a nice option but will break backcompat.

Supersedes #1050
Fixes #478