### PR TITLE
Pass event to onDrop callback

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -84,7 +84,8 @@ export type Props = {
     x: number,
     y: number,
     w: number,
-    h: number
+    h: number,
+    e: Event
   }) => void,
   children: ReactChildrenArray<ReactElement<any>>
 };
@@ -786,7 +787,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     this.dragEnterCounter++;
   };
 
-  onDrop = () => {
+  onDrop = (e: Event) => {
     const { droppingItem } = this.props;
     const { layout } = this.state;
     const { x, y, w, h } = layout.find(l => l.i === droppingItem.i) || {};
@@ -796,7 +797,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.removeDroppingPlaceholder();
 
-    this.props.onDrop({ x, y, w, h });
+    this.props.onDrop({ x, y, w, h, e });
   };
 
   render() {


### PR DESCRIPTION
The onDrop callback is unusable in its current state. This PR will allow the user to retrieve the event that is passed to the onDrop callback such that they will be able to access the dataTransfer object to retrieve information about the gridItem they want to add to the layout.

Fixes issue https://github.com/STRML/react-grid-layout/issues/1058

Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
