### PR TITLE
add-id-prop-to-react-grid-layout

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -50,6 +50,7 @@ type State = {
 };
 
 export type Props = {
+  id: string,
   className: string,
   style: Object,
   width: number,
@@ -117,6 +118,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     //
     // Basic props
     //
+    id: PropTypes.string,
     className: PropTypes.string,
     style: PropTypes.object,
 

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -75,7 +75,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
     //
     // Basic props
     //
-
+    id: PropTypes.string,
     // Optional, but if you are managing width yourself you may want to set the breakpoint
     // yourself as well.
     breakpoint: PropTypes.string,


### PR DESCRIPTION
In order to use more than one react-grid-layout on a page, such as in a scenario where layouts could be nested, an ID prop is needed for dynamic generation, and drag-drop layout functionality. 

I have a fully functional layout editor, using nested react-grid-layouts, enabled by the addition of this additional prop.  I'd really prefer not to have to install my own fork to to support it, and it's a fairly straightforward addition. 