### PR TITLE
Adding layout param to onDrop callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ onResize: ItemCallback,
 // Calls when resize is complete.
 onResizeStop: ItemCallback,
 // Calls when some element has been dropped
-onDrop: (elemParams: { x: number, y: number, e: Event }) => void
+onDrop: (elemParams: { x: number, y: number, w: number, h: number, layout: Layout, e: Event }) => void
 ```
 
 ### Responsive Grid Layout Props

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -85,6 +85,7 @@ export type Props = {
     y: number,
     w: number,
     h: number,
+    layout: Layout,
     e: Event
   }) => void,
   children: ReactChildrenArray<ReactElement<any>>
@@ -802,7 +803,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.removeDroppingPlaceholder();
 
-    this.props.onDrop({ x, y, w, h, e });
+    this.props.onDrop({ x, y, w, h, layout, e });
   };
 
   render() {


### PR DESCRIPTION
This change passes the new layout into the onDrop callback, this will allow us to handle the fact that adding a new item may have caused other items in the grid to shift.

https://github.com/STRML/react-grid-layout/issues/1068