### PR TITLE
Add `enableUserSelectHack` to ReactGridLayout's props

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -51,6 +51,7 @@ type Props = {
   // Draggability
   cancel: string,
   handle: string,
+  enableUserSelectHack: boolean,
 
   x: number,
   y: number,
@@ -148,6 +149,7 @@ export default class GridItem extends React.Component<Props, State> {
     handle: PropTypes.string,
     // Selector for draggable cancel (see react-draggable)
     cancel: PropTypes.string,
+    enableUserSelectHack: PropTypes.bool,
     // Current position of a dropping element
     droppingPosition: PropTypes.shape({
       e: PropTypes.object.isRequired,
@@ -164,7 +166,8 @@ export default class GridItem extends React.Component<Props, State> {
     minW: 1,
     maxH: Infinity,
     maxW: Infinity,
-    transformScale: 1
+    transformScale: 1,
+    enableUserSelectHack: true
   };
 
   state: State = {
@@ -381,6 +384,7 @@ export default class GridItem extends React.Component<Props, State> {
           (this.props.cancel ? "," + this.props.cancel : "")
         }
         scale={this.props.transformScale}
+        enableUserSelectHack={this.props.enableUserSelectHack}
       >
         {child}
       </DraggableCore>
@@ -468,8 +472,8 @@ export default class GridItem extends React.Component<Props, State> {
    */
   onDrag = (e: Event, { node, deltaX, deltaY }: ReactDraggableCallbackData) => {
     if (!this.props.onDrag) return;
-    deltaX /= this.props.transformScale
-    deltaY /= this.props.transformScale
+    deltaX /= this.props.transformScale;
+    deltaY /= this.props.transformScale;
 
     const newPosition: PartialPosition = { top: 0, left: 0 };
 

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -71,6 +71,7 @@ export type Props = {
   useCSSTransforms: boolean,
   transformScale: number,
   droppingItem: $Shape<LayoutItem>,
+  enableUserSelectHack: boolean,
 
   // Callbacks
   onLayoutChange: Layout => void,
@@ -120,6 +121,11 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     //
     className: PropTypes.string,
     style: PropTypes.object,
+
+    //
+    // react-draggable props
+    //
+    enableUserSelectHack: PropTypes.bool,
 
     // This can be set explicitly. If it is not set, it will automatically
     // be set to the container width. Note that resizes will *not* cause this to adjust.
@@ -269,6 +275,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       h: 1,
       w: 1
     },
+    enableUserSelectHack: true,
     onLayoutChange: noop,
     onDragStart: noop,
     onDrag: noop,
@@ -610,7 +617,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       rowHeight,
       maxRows,
       useCSSTransforms,
-      transformScale
+      transformScale,
+      enableUserSelectHack
     } = this.props;
 
     // {...this.state.activeDrag} is pretty slow, actually
@@ -632,6 +640,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         isResizable={false}
         useCSSTransforms={useCSSTransforms}
         transformScale={transformScale}
+        enableUserSelectHack={enableUserSelectHack}
       >
         <div />
       </GridItem>


### PR DESCRIPTION
This property will cause some performance issues. I will manually disable user-select to optimize performance, so I need a prop here.