### PR TITLE
Feature: add initialItemLayout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ compactType: ?('vertical' | 'horizontal') = 'vertical';
 // {i: string, x: number, y: number, w: number, h: number}
 layout: ?array = null, // If not provided, use data-grid props on children
 
+// Initial layout for new items that do not yet possess a layout
+// changing height and width is especially useful if items are too small:
+// { w: 4, h: 4} will create items of 4 blocks per 4 blocks
+initialLayoutItem?: { w: number, h: number, x: number, y: number}
+
 // Margin between items [x, y] in px.
 margin: ?[number, number] = [10, 10],
 

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -60,6 +60,7 @@ export type Props = {
   verticalCompact: boolean,
   compactType: CompactType,
   layout: Layout,
+  initialLayoutItem: $Shape<LayoutItem>,
   margin: [number, number],
   containerPadding: [number, number] | null,
   rowHeight: number,
@@ -160,6 +161,13 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       if (layout === undefined) return;
       validateLayout(layout, "layout");
     },
+
+    initialLayoutItem: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      h: PropTypes.number,
+      w: PropTypes.number
+    }),
 
     //
     // Grid Dimensions
@@ -286,7 +294,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       this.props.children,
       this.props.cols,
       // Legacy support for verticalCompact: false
-      compactType(this.props)
+      compactType(this.props),
+      this.props.initialLayoutItem
     ),
     mounted: false,
     oldDragItem: null,
@@ -344,7 +353,8 @@ export default class ReactGridLayout extends React.Component<Props, State> {
         newLayoutBase,
         nextProps.children,
         nextProps.cols,
-        compactType(nextProps)
+        compactType(nextProps),
+        nextProps.initialLayoutItem
       );
 
       return {

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -117,6 +117,13 @@ export default class ResponsiveReactGridLayout extends React.Component<
       });
     },
 
+    initialLayoutItem: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      h: PropTypes.number,
+      w: PropTypes.number
+    }),
+
     // The width of this component.
     // Required in this propTypes stanza because generateInitialState() will fail without it.
     width: PropTypes.number.isRequired,
@@ -140,6 +147,7 @@ export default class ResponsiveReactGridLayout extends React.Component<
     breakpoints: { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 },
     cols: { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 },
     layouts: {},
+    initialLayoutItem: null,
     margin: [10, 10],
     containerPadding: { lg: null, md: null, sm: null, xs: null, xxs: null },
     onBreakpointChange: noop,
@@ -254,7 +262,8 @@ export default class ResponsiveReactGridLayout extends React.Component<
         layout,
         nextProps.children,
         newCols,
-        compactType
+        compactType,
+        nextProps.initialLayoutItem
       );
 
       // Store the new layout.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -592,7 +592,8 @@ export function synchronizeLayoutWithChildren(
   initialLayout: Layout,
   children: ReactChildren,
   cols: number,
-  compactType: CompactType
+  compactType: CompactType,
+  initialLayoutItem: LayoutItem
 ): Layout {
   initialLayout = initialLayout || [];
 
@@ -620,13 +621,18 @@ export function synchronizeLayoutWithChildren(
         layout[i] = cloneLayoutItem({ ...g, i: child.key });
       } else {
         // Nothing provided: ensure this is added to the bottom
-        layout[i] = cloneLayoutItem({
+        const defaultLayoutItem = {
           w: 1,
           h: 1,
           x: 0,
           y: bottom(layout),
           i: String(child.key)
-        });
+        };
+        // Respect user defaults if any
+        const layoutItem = initialLayoutItem
+          ? { ...defaultLayoutItem, ...initialLayoutItem }
+          : defaultLayoutItem;
+        layout[i] = cloneLayoutItem(layoutItem);
       }
     }
   });


### PR DESCRIPTION
Hi,

This PR add a new option to configure the initial item layout, used as the default layout for new grid items. In some case a 1x1 block is rather small and not suited as the default size of a block. User can configure `initialLayoutItem: { w: 4, h: 4}` for example.

However I have some trouble testing this in my apps. Using `npm link` create a double React version issue (I use 15.x in my app), so I have to somehow copy paste the code. But I've managed to run a small local test and it was ok.

