### PR TITLE
Add link to users recipes wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ RGL is React-only and does not require jQuery.
 - [Grid Layout Props](#grid-layout-props)
 - [Responsive Grid Layout Props](#responsive-grid-layout-props)
 - [Grid Item Props](#grid-item-props)
+- [Users recipes](/STRML/react-grid-layout/wiki/Users-recipes)
 - [Contribute](#contribute)
 - [TODO List](#todo-list)
 


### PR DESCRIPTION
Following https://github.com/STRML/react-grid-layout/pull/1134

This add a "recipes" page that can be managed by contributors to solve common use case that are not trivial to implement: how to get the current layout in responsive mode, how to compute the current bottom etc.