### PR TITLE
Add enzyme testing.

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,12 +1,19 @@
 "use strict";
 
+// If set, we put Babel in "esmMode", i.e. leave import/export intact.
+// Good for webpack and for an esm build.
+const esmMode = process.env.BABEL_MODULE_TYPE === "module";
+const es6Compat = process.env.BABEL_ES_COMPAT === "6" || process.env.NODE_ENV === "test";
+
 module.exports = {
   presets: [
     [
       "@babel/preset-env",
       {
-        targets: "> 0.25%, not dead"
-      }
+        // Don't transpile import/export in esmMode.
+        modules: esmMode ? false : "auto",
+        targets: es6Compat ? "maintained node versions" : "> 0.25%, not dead"
+      },
     ],
     "@babel/react",
     "@babel/preset-flow"

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,8 +1,5 @@
-"use strict";
+// @flow
 
-// If set, we put Babel in "esmMode", i.e. leave import/export intact.
-// Good for webpack and for an esm build.
-const esmMode = process.env.BABEL_MODULE_TYPE === "module";
 const es6Compat = process.env.BABEL_ES_COMPAT === "6" || process.env.NODE_ENV === "test";
 
 module.exports = {
@@ -10,8 +7,6 @@ module.exports = {
     [
       "@babel/preset-env",
       {
-        // Don't transpile import/export in esmMode.
-        modules: esmMode ? false : "auto",
         targets: es6Compat ? "maintained node versions" : "> 0.25%, not dead"
       },
     ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,11 @@
   "rules": {
     "no-console": 0,
     "no-use-before-define": [2, "nofunc"],
+    "no-unused-vars": [1, {
+      "argsIgnorePattern": "^(e|_.*)$",
+      "vars": "local",
+      "varsIgnorePattern": "(debug|^_)"
+    }],
     "prefer-const": 2,
     "react/jsx-boolean-value": [2, "always"]
   },

--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@
 
 [libs]
 interfaces/
+flow-typed/
 
 [options]
 emoji=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "node"
+  - 8
+  - 10
+  - 12
   - "lts/*"
 script:
   - make build test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 dev:
 	@$(BIN)/webpack-dev-server --config webpack-dev-server.config.js \
-	  --hot --progress --colors 
+	  --hot --progress --colors
 
 # Allows usage of `make install`, `make link`
 install link:
@@ -41,7 +41,7 @@ build-example:
 
 view-example:
 	env CONTENT_BASE="/examples/" node ./examples/generate.js
-	@$(BIN)/webpack-dev-server --config webpack-examples.config.js --progress --colors 
+	@$(BIN)/webpack-dev-server --config webpack-examples.config.js --progress --colors
 
 # FIXME flow is usually global
 lint:
@@ -49,7 +49,10 @@ lint:
 	@$(BIN)/eslint --ext .js,.jsx $(LIB) $(TEST)
 
 test:
-	@$(BIN)/jest
+	env NODE_ENV=test $(BIN)/jest
+
+test-watch:
+	env NODE_ENV=test $(BIN)/jest --watch
 
 release-patch: build lint test
 	@$(call release,patch)

--- a/flow-typed/npm/classnames_v2.x.x.js
+++ b/flow-typed/npm/classnames_v2.x.x.js
@@ -1,0 +1,23 @@
+// flow-typed signature: a00cf41b09af4862583460529d5cfcb9
+// flow-typed version: c6154227d1/classnames_v2.x.x/flow_>=v0.104.x
+
+type $npm$classnames$Classes =
+  | string
+  | { [className: string]: *, ... }
+  | false
+  | void
+  | null;
+
+declare module "classnames" {
+  declare module.exports: (
+    ...classes: Array<$npm$classnames$Classes | $npm$classnames$Classes[]>
+  ) => string;
+}
+
+declare module "classnames/bind" {
+  declare module.exports: $Exports<"classnames">;
+}
+
+declare module "classnames/dedupe" {
+  declare module.exports: $Exports<"classnames">;
+}

--- a/flow-typed/npm/enzyme_v3.x.x.js
+++ b/flow-typed/npm/enzyme_v3.x.x.js
@@ -1,0 +1,143 @@
+// flow-typed signature: 931d5482afcb022bcbddb841fd08d683
+// flow-typed version: 5175c53189/enzyme_v3.x.x/flow_>=v0.104.x
+
+declare module "enzyme" {
+  declare type PredicateFunction<T: Wrapper<*>> = (
+    wrapper: T,
+    index: number
+  ) => boolean;
+  declare type UntypedSelector = string | { [key: string]: number|string|boolean, ... };
+  declare type EnzymeSelector = UntypedSelector | React$ElementType;
+
+  // CheerioWrapper is a type alias for an actual cheerio instance
+  // TODO: Reference correct type from cheerio's type declarations
+  declare type CheerioWrapper = any;
+
+  declare class Wrapper<RootComponent> {
+    equals(node: React$Element<any>): boolean,
+    find(selector: UntypedSelector): this,
+    find<T: React$ElementType>(selector: T): ReactWrapper<T>,
+    findWhere(predicate: PredicateFunction<this>): this,
+    filter(selector: UntypedSelector): this,
+    filter<T: React$ElementType>(selector: T): ReactWrapper<T>,
+    filterWhere(predicate: PredicateFunction<this>): this,
+    hostNodes(): this,
+    contains(nodes: React$Node): boolean,
+    containsMatchingElement(node: React$Node): boolean,
+    containsAllMatchingElements(nodes: React$Node): boolean,
+    containsAnyMatchingElements(nodes: React$Node): boolean,
+    dive(option?: { context?: Object, ... }): this,
+    exists(selector?: EnzymeSelector): boolean,
+    isEmptyRender(): boolean,
+    matchesElement(node: React$Node): boolean,
+    hasClass(className: string): boolean,
+    is(selector: EnzymeSelector): boolean,
+    isEmpty(): boolean,
+    not(selector: EnzymeSelector): this,
+    children(selector?: UntypedSelector): this,
+    children<T: React$ElementType>(selector: T): ReactWrapper<T>,
+    childAt(index: number): this,
+    parents(selector?: UntypedSelector): this,
+    parents<T: React$ElementType>(selector: T): ReactWrapper<T>,
+    parent(): this,
+    closest(selector: UntypedSelector): this,
+    closest<T: React$ElementType>(selector: T): ReactWrapper<T>,
+    render(): CheerioWrapper,
+    renderProp(propName: string): (...args: Array<any>) => this,
+    unmount(): this,
+    text(): string,
+    html(): string,
+    invoke(propName: string): (...args: $ReadOnlyArray<any>) => mixed,
+    get(index: number): React$Node,
+    getDOMNode(): HTMLElement | HTMLInputElement,
+    at(index: number): this,
+    first(): this,
+    last(): this,
+    state(key?: string): any,
+    context(key?: string): any,
+    props(): Object,
+    prop(key: string): any,
+    key(): string,
+    simulate(event: string, ...args: Array<any>): this,
+    simulateError(error: Error): this,
+    slice(begin?: number, end?: number): this,
+    setState(state: {...}, callback?: () => void): this,
+    setProps(props: {...}, callback?: () => void): this,
+    setContext(context: Object): this,
+    instance(): React$ElementRef<RootComponent>,
+    update(): this,
+    debug(options?: Object): string,
+    type(): string | Function | null,
+    name(): string,
+    forEach(fn: (node: this, index: number) => mixed): this,
+    map<T>(fn: (node: this, index: number) => T): Array<T>,
+    reduce<T>(
+      fn: (value: T, node: this, index: number) => T,
+      initialValue?: T
+    ): Array<T>,
+    reduceRight<T>(
+      fn: (value: T, node: this, index: number) => T,
+      initialValue?: T
+    ): Array<T>,
+    some(selector: EnzymeSelector): boolean,
+    someWhere(predicate: PredicateFunction<this>): boolean,
+    every(selector: EnzymeSelector): boolean,
+    everyWhere(predicate: PredicateFunction<this>): boolean,
+    length: number
+  }
+
+  declare class ReactWrapper<T> extends Wrapper<T> {
+    constructor(nodes: React$Element<T>, root: any, options?: ?Object): ReactWrapper<T>,
+    mount(): this,
+    ref(refName: string): this,
+    detach(): void
+  }
+
+  declare class ShallowWrapper<T> extends Wrapper<T> {
+    constructor(
+      nodes: React$Element<T>,
+      root: any,
+      options?: ?Object
+    ): ShallowWrapper<T>,
+    equals(node: React$Node): boolean,
+    shallow(options?: { context?: Object, ... }): ShallowWrapper<T>,
+    getElement(): React$Node,
+    getElements(): Array<React$Node>
+  }
+
+  declare function shallow<T>(
+    node: React$Element<T>,
+    options?: {
+      context?: Object,
+      disableLifecycleMethods?: boolean,
+      ...
+    }
+  ): ShallowWrapper<T>;
+  declare function mount<T>(
+    node: React$Element<T>,
+    options?: {
+      context?: Object,
+      attachTo?: HTMLElement,
+      childContextTypes?: Object,
+      ...
+    }
+  ): ReactWrapper<T>;
+  declare function render(
+    node: React$Node,
+    options?: { context?: Object, ... }
+  ): CheerioWrapper;
+
+  declare module.exports: {
+    configure(options: {
+      Adapter?: any,
+      disableLifecycleMethods?: boolean,
+      ...
+    }): void,
+    render: typeof render,
+    mount: typeof mount,
+    shallow: typeof shallow,
+    ShallowWrapper: typeof ShallowWrapper,
+    ReactWrapper: typeof ReactWrapper,
+    ...
+  };
+}

--- a/flow-typed/npm/jest_v24.x.x.js
+++ b/flow-typed/npm/jest_v24.x.x.js
@@ -1,0 +1,1182 @@
+// flow-typed signature: 27f8467378a99b6130bd20f54f31a644
+// flow-typed version: 6cb9e99836/jest_v24.x.x/flow_>=v0.104.x
+
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+ (...args: TArguments): TReturn,
+ /**
+  * An object for introspecting mock calls
+  */
+ mock: {
+  /**
+   * An array that represents all calls that have been made into this mock
+   * function. Each call is represented by an array of arguments that were
+   * passed during the call.
+   */
+  calls: Array<TArguments>,
+  /**
+   * An array that contains all the object instances that have been
+   * instantiated from this mock function.
+   */
+  instances: Array<TReturn>,
+  /**
+   * An array that contains all the object results that have been
+   * returned by this mock function call
+   */
+  results: Array<{
+   isThrow: boolean,
+   value: TReturn,
+   ...
+  }>,
+  ...
+ },
+ /**
+  * Resets all information stored in the mockFn.mock.calls and
+  * mockFn.mock.instances arrays. Often this is useful when you want to clean
+  * up a mock's usage data between two assertions.
+  */
+ mockClear(): void,
+ /**
+  * Resets all information stored in the mock. This is useful when you want to
+  * completely restore a mock back to its initial state.
+  */
+ mockReset(): void,
+ /**
+  * Removes the mock and restores the initial implementation. This is useful
+  * when you want to mock functions in certain test cases and restore the
+  * original implementation in others. Beware that mockFn.mockRestore only
+  * works when mock was created with jest.spyOn. Thus you have to take care of
+  * restoration yourself when manually assigning jest.fn().
+  */
+ mockRestore(): void,
+ /**
+  * Accepts a function that should be used as the implementation of the mock.
+  * The mock itself will still record all calls that go into and instances
+  * that come from itself -- the only difference is that the implementation
+  * will also be executed when the mock is called.
+  */
+ mockImplementation(
+   fn: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Accepts a function that will be used as an implementation of the mock for
+  * one call to the mocked function. Can be chained so that multiple function
+  * calls produce different results.
+  */
+ mockImplementationOnce(
+   fn: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Accepts a string to use in test result output in place of "jest.fn()" to
+  * indicate which mock function is being referenced.
+  */
+ mockName(name: string): JestMockFn<TArguments, TReturn>,
+ /**
+  * Just a simple sugar function for returning `this`
+  */
+ mockReturnThis(): void,
+ /**
+  * Accepts a value that will be returned whenever the mock function is called.
+  */
+ mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+ /**
+  * Sugar for only returning a value once inside your mock
+  */
+ mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+ /**
+  * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
+  */
+ mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+ /**
+  * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
+  */
+ mockResolvedValueOnce(
+   value: TReturn
+ ): JestMockFn<TArguments, Promise<TReturn>>,
+ /**
+  * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
+  */
+ mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+ /**
+  * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
+  */
+ mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+ ...
+};
+
+type JestAsymmetricEqualityType = { /**
+ * A custom Jasmine equality tester
+ */
+asymmetricMatch(value: mixed): boolean, ... };
+
+type JestCallsType = {
+ allArgs(): mixed,
+ all(): mixed,
+ any(): boolean,
+ count(): number,
+ first(): mixed,
+ mostRecent(): mixed,
+ reset(): void,
+ ...
+};
+
+type JestClockType = {
+ install(): void,
+ mockDate(date: Date): void,
+ tick(milliseconds?: number): void,
+ uninstall(): void,
+ ...
+};
+
+type JestMatcherResult = {
+ message?: string | (() => string),
+ pass: boolean,
+ ...
+};
+
+type JestMatcher = (
+  received: any,
+  ...actual: Array<any>
+) => JestMatcherResult | Promise<JestMatcherResult>;
+
+type JestPromiseType = {
+ /**
+  * Use rejects to unwrap the reason of a rejected promise so any other
+  * matcher can be chained. If the promise is fulfilled the assertion fails.
+  */
+ rejects: JestExpectType,
+ /**
+  * Use resolves to unwrap the value of a fulfilled promise so any other
+  * matcher can be chained. If the promise is rejected the assertion fails.
+  */
+ resolves: JestExpectType,
+ ...
+};
+
+/**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
+ *  Plugin: jest-styled-components
+ */
+
+type JestStyledComponentsMatcherValue =
+  | string
+  | JestAsymmetricEqualityType
+  | RegExp
+  | typeof undefined;
+
+type JestStyledComponentsMatcherOptions = {
+ media?: string,
+ modifier?: string,
+ supports?: string,
+ ...
+};
+
+type JestStyledComponentsMatchersType = { toHaveStyleRule(
+  property: string,
+  value: JestStyledComponentsMatcherValue,
+  options?: JestStyledComponentsMatcherOptions
+): void, ... };
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+ // 5.x
+ toBeEmpty(): void,
+ toBePresent(): void,
+ // 6.x
+ toBeChecked(): void,
+ toBeDisabled(): void,
+ toBeEmptyRender(): void,
+ toContainMatchingElement(selector: string): void,
+ toContainMatchingElements(n: number, selector: string): void,
+ toContainExactlyOneMatchingElement(selector: string): void,
+ toContainReact(element: React$Element<any>): void,
+ toExist(): void,
+ toHaveClassName(className: string): void,
+ toHaveHTML(html: string): void,
+ toHaveProp: ((propKey: string, propValue?: any) => void) &
+   ((props: {...}) => void),
+ toHaveRef(refName: string): void,
+ toHaveState: ((stateKey: string, stateValue?: any) => void) &
+   ((state: {...}) => void),
+ toHaveStyle: ((styleKey: string, styleValue?: any) => void) &
+   ((style: {...}) => void),
+ toHaveTagName(tagName: string): void,
+ toHaveText(text: string): void,
+ toHaveValue(value: any): void,
+ toIncludeText(text: string): void,
+ toMatchElement(
+   element: React$Element<any>,
+   options?: {| ignoreProps?: boolean, verbose?: boolean |}
+ ): void,
+ toMatchSelector(selector: string): void,
+ // 7.x
+ toHaveDisplayName(name: string): void,
+ ...
+};
+
+// DOM testing library extensions (jest-dom)
+// https://github.com/testing-library/jest-dom
+type DomTestingLibraryType = {
+ /**
+  * @deprecated
+  */
+ toBeInTheDOM(container?: HTMLElement): void,
+ toBeInTheDocument(): void,
+ toBeVisible(): void,
+ toBeEmpty(): void,
+ toBeDisabled(): void,
+ toBeEnabled(): void,
+ toBeInvalid(): void,
+ toBeRequired(): void,
+ toBeValid(): void,
+ toContainElement(element: HTMLElement | null): void,
+ toContainHTML(htmlText: string): void,
+ toHaveAttribute(attr: string, value?: any): void,
+ toHaveClass(...classNames: string[]): void,
+ toHaveFocus(): void,
+ toHaveFormValues(expectedValues: { [name: string]: any, ... }): void,
+ toHaveStyle(css: string): void,
+ toHaveTextContent(
+   text: string | RegExp,
+   options?: { normalizeWhitespace: boolean, ... }
+ ): void,
+ toHaveValue(value?: string | string[] | number): void,
+ ...
+};
+
+// Jest JQuery Matchers: https://github.com/unindented/custom-jquery-matchers
+type JestJQueryMatchersType = {
+ toExist(): void,
+ toHaveLength(len: number): void,
+ toHaveId(id: string): void,
+ toHaveClass(className: string): void,
+ toHaveTag(tag: string): void,
+ toHaveAttr(key: string, val?: any): void,
+ toHaveProp(key: string, val?: any): void,
+ toHaveText(text: string | RegExp): void,
+ toHaveData(key: string, val?: any): void,
+ toHaveValue(val: any): void,
+ toHaveCss(css: { [key: string]: any, ... }): void,
+ toBeChecked(): void,
+ toBeDisabled(): void,
+ toBeEmpty(): void,
+ toBeHidden(): void,
+ toBeSelected(): void,
+ toBeVisible(): void,
+ toBeFocused(): void,
+ toBeInDom(): void,
+ toBeMatchedBy(sel: string): void,
+ toHaveDescendant(sel: string): void,
+ toHaveDescendantWithText(sel: string, text: string | RegExp): void,
+ ...
+};
+
+// Jest Extended Matchers: https://github.com/jest-community/jest-extended
+type JestExtendedMatchersType = {
+ /**
+  * Note: Currently unimplemented
+  * Passing assertion
+  *
+  * @param {String} message
+  */
+ //  pass(message: string): void;
+
+ /**
+  * Note: Currently unimplemented
+  * Failing assertion
+  *
+  * @param {String} message
+  */
+ //  fail(message: string): void;
+
+ /**
+  * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
+  */
+ toBeEmpty(): void,
+ /**
+  * Use .toBeOneOf when checking if a value is a member of a given Array.
+  * @param {Array.<*>} members
+  */
+ toBeOneOf(members: any[]): void,
+ /**
+  * Use `.toBeNil` when checking a value is `null` or `undefined`.
+  */
+ toBeNil(): void,
+ /**
+  * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
+  * @param {Function} predicate
+  */
+ toSatisfy(predicate: (n: any) => boolean): void,
+ /**
+  * Use `.toBeArray` when checking if a value is an `Array`.
+  */
+ toBeArray(): void,
+ /**
+  * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
+  * @param {Number} x
+  */
+ toBeArrayOfSize(x: number): void,
+ /**
+  * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+  * @param {Array.<*>} members
+  */
+ toIncludeAllMembers(members: any[]): void,
+ /**
+  * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
+  * @param {Array.<*>} members
+  */
+ toIncludeAnyMembers(members: any[]): void,
+ /**
+  * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
+  * @param {Function} predicate
+  */
+ toSatisfyAll(predicate: (n: any) => boolean): void,
+ /**
+  * Use `.toBeBoolean` when checking if a value is a `Boolean`.
+  */
+ toBeBoolean(): void,
+ /**
+  * Use `.toBeTrue` when checking a value is equal (===) to `true`.
+  */
+ toBeTrue(): void,
+ /**
+  * Use `.toBeFalse` when checking a value is equal (===) to `false`.
+  */
+ toBeFalse(): void,
+ /**
+  * Use .toBeDate when checking if a value is a Date.
+  */
+ toBeDate(): void,
+ /**
+  * Use `.toBeFunction` when checking if a value is a `Function`.
+  */
+ toBeFunction(): void,
+ /**
+  * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
+  *
+  * Note: Required Jest version >22
+  * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
+  *
+  * @param {Mock} mock
+  */
+ toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void,
+ /**
+  * Use `.toBeNumber` when checking if a value is a `Number`.
+  */
+ toBeNumber(): void,
+ /**
+  * Use `.toBeNaN` when checking a value is `NaN`.
+  */
+ toBeNaN(): void,
+ /**
+  * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
+  */
+ toBeFinite(): void,
+ /**
+  * Use `.toBePositive` when checking if a value is a positive `Number`.
+  */
+ toBePositive(): void,
+ /**
+  * Use `.toBeNegative` when checking if a value is a negative `Number`.
+  */
+ toBeNegative(): void,
+ /**
+  * Use `.toBeEven` when checking if a value is an even `Number`.
+  */
+ toBeEven(): void,
+ /**
+  * Use `.toBeOdd` when checking if a value is an odd `Number`.
+  */
+ toBeOdd(): void,
+ /**
+  * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
+  *
+  * @param {Number} start
+  * @param {Number} end
+  */
+ toBeWithin(start: number, end: number): void,
+ /**
+  * Use `.toBeObject` when checking if a value is an `Object`.
+  */
+ toBeObject(): void,
+ /**
+  * Use `.toContainKey` when checking if an object contains the provided key.
+  *
+  * @param {String} key
+  */
+ toContainKey(key: string): void,
+ /**
+  * Use `.toContainKeys` when checking if an object has all of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainKeys(keys: string[]): void,
+ /**
+  * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainAllKeys(keys: string[]): void,
+ /**
+  * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainAnyKeys(keys: string[]): void,
+ /**
+  * Use `.toContainValue` when checking if an object contains the provided value.
+  *
+  * @param {*} value
+  */
+ toContainValue(value: any): void,
+ /**
+  * Use `.toContainValues` when checking if an object contains all of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainValues(values: any[]): void,
+ /**
+  * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainAllValues(values: any[]): void,
+ /**
+  * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainAnyValues(values: any[]): void,
+ /**
+  * Use `.toContainEntry` when checking if an object contains the provided entry.
+  *
+  * @param {Array.<String, String>} entry
+  */
+ toContainEntry(entry: [string, string]): void,
+ /**
+  * Use `.toContainEntries` when checking if an object contains all of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainAllEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainAnyEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toBeExtensible` when checking if an object is extensible.
+  */
+ toBeExtensible(): void,
+ /**
+  * Use `.toBeFrozen` when checking if an object is frozen.
+  */
+ toBeFrozen(): void,
+ /**
+  * Use `.toBeSealed` when checking if an object is sealed.
+  */
+ toBeSealed(): void,
+ /**
+  * Use `.toBeString` when checking if a value is a `String`.
+  */
+ toBeString(): void,
+ /**
+  * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
+  *
+  * @param {String} string
+  */
+ toEqualCaseInsensitive(string: string): void,
+ /**
+  * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
+  *
+  * @param {String} prefix
+  */
+ toStartWith(prefix: string): void,
+ /**
+  * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
+  *
+  * @param {String} suffix
+  */
+ toEndWith(suffix: string): void,
+ /**
+  * Use `.toInclude` when checking if a `String` includes the given `String` substring.
+  *
+  * @param {String} substring
+  */
+ toInclude(substring: string): void,
+ /**
+  * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
+  *
+  * @param {String} substring
+  * @param {Number} times
+  */
+ toIncludeRepeated(substring: string, times: number): void,
+ /**
+  * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
+  *
+  * @param {Array.<String>} substring
+  */
+ toIncludeMultiple(substring: string[]): void,
+ ...
+};
+
+interface JestExpectType {
+  not: JestExpectType &
+    EnzymeMatchersType &
+    DomTestingLibraryType &
+    JestJQueryMatchersType &
+    JestStyledComponentsMatchersType &
+    JestExtendedMatchersType;
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void;
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void;
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void;
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void;
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void;
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void;
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void;
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void;
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void;
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void;
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void;
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void;
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void;
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void;
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void;
+  toBeCalled(): void;
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void;
+  toBeCalledTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveBeenNthCalledWith(nthCall: number, ...args: Array<any>): void;
+  nthCalledWith(nthCall: number, ...args: Array<any>): void;
+  /**
+   *
+   */
+  toHaveReturned(): void;
+  toReturn(): void;
+  /**
+   *
+   */
+  toHaveReturnedTimes(number: number): void;
+  toReturnTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveReturnedWith(value: any): void;
+  toReturnWith(value: any): void;
+  /**
+   *
+   */
+  toHaveLastReturnedWith(value: any): void;
+  lastReturnedWith(value: any): void;
+  /**
+   *
+   */
+  toHaveNthReturnedWith(nthCall: number, value: any): void;
+  nthReturnedWith(nthCall: number, value: any): void;
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void;
+  toBeCalledWith(...args: Array<any>): void;
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void;
+  lastCalledWith(...args: Array<any>): void;
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void;
+  /**
+   *
+   */
+  toHaveProperty(propPath: string | $ReadOnlyArray<string>, value?: any): void;
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void;
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void;
+  /**
+   * Use .toStrictEqual to check that a javascript object matches a subset of the properties of an object.
+   */
+  toStrictEqual(value: any): void;
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(propertyMatchers?: any, name?: string): void;
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(name: string): void;
+
+  toMatchInlineSnapshot(snapshot?: string): void;
+  toMatchInlineSnapshot(propertyMatchers?: any, snapshot?: string): void;
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | Class<Error> | RegExp): void;
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void;
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void;
+  toThrowErrorMatchingInlineSnapshot(snapshot?: string): void;
+}
+
+type JestObjectType = {
+ /**
+  *  Disables automatic mocking in the module loader.
+  *
+  *  After this method is called, all `require()`s will return the real
+  *  versions of each module (rather than a mocked version).
+  */
+ disableAutomock(): JestObjectType,
+ /**
+  * An un-hoisted version of disableAutomock
+  */
+ autoMockOff(): JestObjectType,
+ /**
+  * Enables automatic mocking in the module loader.
+  */
+ enableAutomock(): JestObjectType,
+ /**
+  * An un-hoisted version of enableAutomock
+  */
+ autoMockOn(): JestObjectType,
+ /**
+  * Clears the mock.calls and mock.instances properties of all mocks.
+  * Equivalent to calling .mockClear() on every mocked function.
+  */
+ clearAllMocks(): JestObjectType,
+ /**
+  * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+  * mocked function.
+  */
+ resetAllMocks(): JestObjectType,
+ /**
+  * Restores all mocks back to their original value.
+  */
+ restoreAllMocks(): JestObjectType,
+ /**
+  * Removes any pending timers from the timer system.
+  */
+ clearAllTimers(): void,
+ /**
+  * Returns the number of fake timers still left to run.
+  */
+ getTimerCount(): number,
+ /**
+  * The same as `mock` but not moved to the top of the expectation by
+  * babel-jest.
+  */
+ doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+ /**
+  * The same as `unmock` but not moved to the top of the expectation by
+  * babel-jest.
+  */
+ dontMock(moduleName: string): JestObjectType,
+ /**
+  * Returns a new, unused mock function. Optionally takes a mock
+  * implementation.
+  */
+ fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+   implementation?: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Determines if the given function is a mocked function.
+  */
+ isMockFunction(fn: Function): boolean,
+ /**
+  * Given the name of a module, use the automatic mocking system to generate a
+  * mocked version of the module for you.
+  */
+ genMockFromModule(moduleName: string): any,
+ /**
+  * Mocks a module with an auto-mocked version when it is being required.
+  *
+  * The second argument can be used to specify an explicit module factory that
+  * is being run instead of using Jest's automocking feature.
+  *
+  * The third argument can be used to create virtual mocks -- mocks of modules
+  * that don't exist anywhere in the system.
+  */
+ mock(
+   moduleName: string,
+   moduleFactory?: any,
+   options?: Object
+ ): JestObjectType,
+ /**
+  * Returns the actual module instead of a mock, bypassing all checks on
+  * whether the module should receive a mock implementation or not.
+  */
+ requireActual(moduleName: string): any,
+ /**
+  * Returns a mock module instead of the actual module, bypassing all checks
+  * on whether the module should be required normally or not.
+  */
+ requireMock(moduleName: string): any,
+ /**
+  * Resets the module registry - the cache of all required modules. This is
+  * useful to isolate modules where local state might conflict between tests.
+  */
+ resetModules(): JestObjectType,
+ /**
+  * Creates a sandbox registry for the modules that are loaded inside the
+  * callback function. This is useful to isolate specific modules for every
+  * test so that local module state doesn't conflict between tests.
+  */
+ isolateModules(fn: () => void): JestObjectType,
+ /**
+  * Exhausts the micro-task queue (usually interfaced in node via
+  * process.nextTick).
+  */
+ runAllTicks(): void,
+ /**
+  * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+  * setInterval(), and setImmediate()).
+  */
+ runAllTimers(): void,
+ /**
+  * Exhausts all tasks queued by setImmediate().
+  */
+ runAllImmediates(): void,
+ /**
+  * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+  * or setInterval() and setImmediate()).
+  */
+ advanceTimersByTime(msToRun: number): void,
+ /**
+  * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+  * or setInterval() and setImmediate()).
+  *
+  * Renamed to `advanceTimersByTime`.
+  */
+ runTimersToTime(msToRun: number): void,
+ /**
+  * Executes only the macro-tasks that are currently pending (i.e., only the
+  * tasks that have been queued by setTimeout() or setInterval() up to this
+  * point)
+  */
+ runOnlyPendingTimers(): void,
+ /**
+  * Explicitly supplies the mock object that the module system should return
+  * for the specified module. Note: It is recommended to use jest.mock()
+  * instead.
+  */
+ setMock(moduleName: string, moduleExports: any): JestObjectType,
+ /**
+  * Indicates that the module system should never return a mocked version of
+  * the specified module from require() (e.g. that it should always return the
+  * real module).
+  */
+ unmock(moduleName: string): JestObjectType,
+ /**
+  * Instructs Jest to use fake versions of the standard timer functions
+  * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+  * setImmediate and clearImmediate).
+  */
+ useFakeTimers(): JestObjectType,
+ /**
+  * Instructs Jest to use the real versions of the standard timer functions.
+  */
+ useRealTimers(): JestObjectType,
+ /**
+  * Creates a mock function similar to jest.fn but also tracks calls to
+  * object[methodName].
+  */
+ spyOn(
+   object: Object,
+   methodName: string,
+   accessType?: 'get' | 'set'
+ ): JestMockFn<any, any>,
+ /**
+  * Set the default timeout interval for tests and before/after hooks in milliseconds.
+  * Note: The default timeout interval is 5 seconds if this method is not called.
+  */
+ setTimeout(timeout: number): JestObjectType,
+ ...
+};
+
+type JestSpyType = { calls: JestCallsType, ... };
+
+type JestDoneFn = {|
+ (): void,
+ fail: (error: Error) => void,
+|};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  timeout?: number
+): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+ /**
+  * Creates a block that groups together several related tests in one "test suite"
+  */
+ (name: JestTestName, fn: () => void): void,
+ /**
+  * Only run this describe block
+  */
+ only(name: JestTestName, fn: () => void): void,
+ /**
+  * Skip running this describe block
+  */
+ skip(name: JestTestName, fn: () => void): void,
+ /**
+  * each runs this test against array of argument arrays per each run
+  *
+  * @param {table} table of Test
+  */
+ each(
+   ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+ ): (
+   name: JestTestName,
+   fn?: (...args: Array<any>) => ?Promise<mixed>,
+   timeout?: number
+ ) => void,
+ ...
+};
+
+/** An individual test unit */
+declare var it: {
+ /**
+  * An individual test unit
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ (
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * Only run this test
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ only: {|
+   (
+     name: JestTestName,
+     fn?: (done: JestDoneFn) => ?Promise<mixed>,
+     timeout?: number
+   ): void,
+   each(
+     ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+   ): (
+     name: JestTestName,
+     fn?: (...args: Array<any>) => ?Promise<mixed>,
+     timeout?: number
+   ) => void
+ |},
+ /**
+  * Skip running this test
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ skip(
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * Highlight planned tests in the summary output
+  *
+  * @param {String} Name of Test to do
+  */
+ todo(name: string): void,
+ /**
+  * Run the test concurrently
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ concurrent(
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * each runs this test against array of argument arrays per each run
+  *
+  * @param {table} table of Test
+  */
+ each(
+   ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+ ): (
+   name: JestTestName,
+   fn?: (...args: Array<any>) => ?Promise<mixed>,
+   timeout?: number
+ ) => void,
+ ...
+};
+
+declare function fit(
+  name: JestTestName,
+  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+type JestPrettyFormatColors = {
+ comment: {
+  close: string,
+  open: string,
+  ...
+ },
+ content: {
+  close: string,
+  open: string,
+  ...
+ },
+ prop: {
+  close: string,
+  open: string,
+  ...
+ },
+ tag: {
+  close: string,
+  open: string,
+  ...
+ },
+ value: {
+  close: string,
+  open: string,
+  ...
+ },
+ ...
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+ print: (
+   val: any,
+   serialize: JestPrettyFormatPrint,
+   indent: JestPrettyFormatIndent,
+   opts: JestPrettyFormatOptions,
+   colors: JestPrettyFormatColors
+ ) => string,
+ test: any => boolean,
+ ...
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+ /** The object that you want to make assertions against */
+ (
+   value: any
+ ): JestExpectType &
+   JestPromiseType &
+   EnzymeMatchersType &
+   DomTestingLibraryType &
+   JestJQueryMatchersType &
+   JestStyledComponentsMatchersType &
+   JestExtendedMatchersType,
+ /** Add additional Jasmine matchers to Jest's roster */
+ extend(matchers: { [name: string]: JestMatcher, ... }): void,
+ /** Add a module that formats application-specific data structures. */
+ addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
+ assertions(expectedAssertions: number): void,
+ hasAssertions(): void,
+ any(value: mixed): JestAsymmetricEqualityType,
+ anything(): any,
+ arrayContaining(value: Array<mixed>): Array<mixed>,
+ objectContaining(value: Object): Object,
+ /** Matches any received string that contains the exact expected string. */
+ stringContaining(value: string): string,
+ stringMatching(value: string | RegExp): string,
+ not: {
+  arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+  objectContaining: (value: {...}) => Object,
+  stringContaining: (value: string) => string,
+  stringMatching: (value: string | RegExp) => string,
+  ...
+ },
+ ...
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+ DEFAULT_TIMEOUT_INTERVAL: number,
+ any(value: mixed): JestAsymmetricEqualityType,
+ anything(): any,
+ arrayContaining(value: Array<mixed>): Array<mixed>,
+ clock(): JestClockType,
+ createSpy(name: string): JestSpyType,
+ createSpyObj(
+   baseName: string,
+   methodNames: Array<string>
+ ): { [methodName: string]: JestSpyType, ... },
+ objectContaining(value: Object): Object,
+ stringMatching(value: string): string,
+ ...
+};

--- a/lib/ResponsiveReactGridLayout.jsx
+++ b/lib/ResponsiveReactGridLayout.jsx
@@ -7,15 +7,17 @@ import {
   cloneLayout,
   synchronizeLayoutWithChildren,
   validateLayout,
-  noop
+  noop,
+  type Layout
 } from "./utils";
 import {
   getBreakpointFromWidth,
   getColsFromBreakpoint,
-  findOrGenerateResponsiveLayout
+  findOrGenerateResponsiveLayout,
+  type ResponsiveLayout,
+  type Breakpoints,
 } from "./responsiveUtils";
 import ReactGridLayout from "./ReactGridLayout";
-import type { Layout } from "./utils";
 
 const type = obj => Object.prototype.toString.call(obj);
 
@@ -46,9 +48,9 @@ type Props<Breakpoint: string = string> = {|
 
   // Responsive config
   breakpoint?: ?Breakpoint,
-  breakpoints: { [key: Breakpoint]: number },
+  breakpoints: Breakpoints<Breakpoint>,
   cols: { [key: Breakpoint]: number },
-  layouts: { [key: Breakpoint]: Layout },
+  layouts: ResponsiveLayout<Breakpoint>,
   width: number,
   margin: { [key: Breakpoint]: [number, number] } | [number, number],
   containerPadding: { [key: Breakpoint]: [number, number] } | [number, number],

--- a/lib/responsiveUtils.js
+++ b/lib/responsiveUtils.js
@@ -4,22 +4,15 @@ import { cloneLayout, compact, correctBounds } from "./utils";
 
 import type { CompactType, Layout } from "./utils";
 
-export type ResponsiveLayout = {
-  lg?: Layout,
-  md?: Layout,
-  sm?: Layout,
-  xs?: Layout,
-  xxs?: Layout
+export type Breakpoint = string;
+export type DefaultBreakpoints = 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
+
+// + indicates read-only
+export type ResponsiveLayout<T: Breakpoint> = {
+  +[breakpoint: T]: Layout
 };
-
-type Breakpoint = string;
-
-type Breakpoints = {
-  lg?: number,
-  md?: number,
-  sm?: number,
-  xs?: number,
-  xxs?: number
+export type Breakpoints<T: Breakpoint> = {
+  +[breakpoint: T]: number
 };
 
 /**
@@ -30,7 +23,7 @@ type Breakpoints = {
  * @return {String}       Highest breakpoint that is less than width.
  */
 export function getBreakpointFromWidth(
-  breakpoints: Breakpoints,
+  breakpoints: Breakpoints<Breakpoint>,
   width: number
 ): Breakpoint {
   const sorted = sortBreakpoints(breakpoints);
@@ -50,7 +43,7 @@ export function getBreakpointFromWidth(
  */
 export function getColsFromBreakpoint(
   breakpoint: Breakpoint,
-  cols: Breakpoints
+  cols: Breakpoints<Breakpoint>
 ): number {
   if (!cols[breakpoint]) {
     throw new Error(
@@ -77,8 +70,8 @@ export function getColsFromBreakpoint(
  * @return {Array}             New layout.
  */
 export function findOrGenerateResponsiveLayout(
-  layouts: ResponsiveLayout,
-  breakpoints: Breakpoints,
+  layouts: ResponsiveLayout<Breakpoint>,
+  breakpoints: Breakpoints<Breakpoint>,
   breakpoint: Breakpoint,
   lastBreakpoint: Breakpoint,
   cols: number,
@@ -110,7 +103,7 @@ export function findOrGenerateResponsiveLayout(
  * @param  {Object} breakpoints Key/value pair of breakpoint names to widths.
  * @return {Array}              Sorted breakpoints.
  */
-export function sortBreakpoints(breakpoints: Breakpoints): Array<Breakpoint> {
+export function sortBreakpoints(breakpoints: Breakpoints<Breakpoint>): Array<Breakpoint> {
   const keys: Array<string> = Object.keys(breakpoints);
   return keys.sort(function(a, b) {
     return breakpoints[a] - breakpoints[b];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,7 @@ export type LayoutItem = {
   isDraggable?: ?boolean,
   isResizable?: ?boolean
 };
-export type Layout = Array<LayoutItem>;
+export type Layout = $ReadOnlyArray<LayoutItem>;
 export type Position = {
   left: number,
   top: number,
@@ -165,6 +165,8 @@ export function collides(l1: LayoutItem, l2: LayoutItem): boolean {
  * Given a layout, compact it. This involves going down each y coordinate and removing gaps
  * between items.
  *
+ * Does not modify layout items (clones). Creates a new layout array.
+ *
  * @param  {Array} layout Layout.
  * @param  {Boolean} verticalCompact Whether or not to compact the layout
  *   vertically.
@@ -247,6 +249,9 @@ function resolveCompactionCollision(
 
 /**
  * Compact an item in the layout.
+ *
+ * Modifies item.
+ *
  */
 export function compactItem(
   compareWith: Layout,
@@ -293,6 +298,8 @@ export function compactItem(
 
 /**
  * Given a layout, make sure all elements fit within its bounds.
+ *
+ * Modifies layout items.
  *
  * @param  {Array} layout Layout array.
  * @param  {Number} bounds Number of columns.
@@ -372,6 +379,8 @@ export function getStatics(layout: Layout): Array<LayoutItem> {
 /**
  * Move an element. Responsible for doing cascading movements of other elements.
  *
+ * Modifies layout items.
+ *
  * @param  {Array}      layout            Full layout to modify.
  * @param  {LayoutItem} l                 element to move.
  * @param  {Number}     [x]               X position in grid units.
@@ -416,6 +425,7 @@ export function moveElement(
       : compactType === "horizontal" && typeof x === "number"
       ? oldX >= x
       : false;
+  // $FlowIgnore acceptable modification of read-only array as it was recently cloned
   if (movingUp) sorted = sorted.reverse();
   const collisions = getAllCollisions(sorted, l);
 
@@ -579,8 +589,14 @@ export function sortLayoutItems(
   else return sortLayoutItemsByRowCol(layout);
 }
 
+/**
+ * Sort layout items by row ascending and column ascending.
+ *
+ * Does not modify Layout.
+ */
 export function sortLayoutItemsByRowCol(layout: Layout): Layout {
-  return [].concat(layout).sort(function(a, b) {
+  // Slice to clone array as sort modifies
+  return layout.slice(0).sort(function(a, b) {
     if (a.y > b.y || (a.y === b.y && a.x > b.x)) {
       return 1;
     } else if (a.y === b.y && a.x === b.x) {
@@ -591,8 +607,13 @@ export function sortLayoutItemsByRowCol(layout: Layout): Layout {
   });
 }
 
+/**
+ * Sort layout items by column ascending then row ascending.
+ *
+ * Does not modify Layout.
+ */
 export function sortLayoutItemsByColRow(layout: Layout): Layout {
-  return [].concat(layout).sort(function(a, b) {
+  return layout.slice(0).sort(function(a, b) {
     if (a.x > b.x || (a.x === b.x && a.y > b.y)) {
       return 1;
     }
@@ -603,6 +624,8 @@ export function sortLayoutItemsByColRow(layout: Layout): Layout {
 /**
  * Generate a layout using the initialLayout and children as a template.
  * Missing entries will be added, extraneous ones will be truncated.
+ *
+ * Does not modify initialLayout.
  *
  * @param  {Array}  initialLayout Layout passed in through props.
  * @param  {String} breakpoint    Current responsive breakpoint.
@@ -618,7 +641,7 @@ export function synchronizeLayoutWithChildren(
   initialLayout = initialLayout || [];
 
   // Generate one layout item per child.
-  let layout: Layout = [];
+  const layout: LayoutItem[] = [];
   React.Children.forEach(children, (child: ReactElement<any>, i: number) => {
     // Don't overwrite if it already exists.
     const exists = getLayoutItem(initialLayout, String(child.key));
@@ -653,10 +676,8 @@ export function synchronizeLayoutWithChildren(
   });
 
   // Correct the layout.
-  layout = correctBounds(layout, { cols: cols });
-  layout = compact(layout, compactType, cols);
-
-  return layout;
+  const correctedLayout = correctBounds(layout, { cols: cols });
+  return compact(correctedLayout, compactType, cols);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-hot-loader": "^4.12.18",
     "react-transform-hmr": "^1.0.2",
     "style-loader": "^1.1.2",
+    "timsort": "^0.3.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-preval": "^4.0.0",
-    "chance": "^1.1.4",
     "css-loader": "^3.4.2",
     "ejs": "^3.0.1",
     "enzyme": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,12 @@
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-preval": "^4.0.0",
+    "chance": "^1.1.4",
     "css-loader": "^3.4.2",
     "ejs": "^3.0.1",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.4.4",
     "eslint": "^6.8.0",
     "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-mocha": "^6.2.2",
@@ -64,7 +68,7 @@
     "flow-bin": "^0.119.0",
     "husky": "^3.0.9",
     "imports-loader": "^0.8.0",
-    "jest-cli": "^24.9.0",
+    "jest": "^24.9.0",
     "lint-staged": "^9.5.0",
     "lodash": "^4.17.5",
     "opener": "^1.4.3",
@@ -82,6 +86,12 @@
     "registry": "https://registry.npmjs.org"
   },
   "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>test/util/setupTests.js"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "testMatch": [
       "<rootDir>/test/spec/*.js"
     ],

--- a/test/examples/0-showcase.jsx
+++ b/test/examples/0-showcase.jsx
@@ -9,7 +9,6 @@ const ResponsiveReactGridLayout = WidthProvider(Responsive);
 type Props = {|
   className: string,
   cols: {[string]: number},
-  initialLayout: Layout,
   onLayoutChange: Function,
   rowHeight: number,
 |};
@@ -26,14 +25,13 @@ export default class ShowcaseLayout extends React.Component<Props, State> {
     rowHeight: 30,
     onLayoutChange: function() {},
     cols: { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 },
-    initialLayout: generateLayout()
   };
 
   state = {
     currentBreakpoint: "lg",
     compactType: "vertical",
     mounted: false,
-    layouts: { lg: this.props.initialLayout }
+    layouts: { lg: generateLayout() }
   };
 
   componentDidMount() {
@@ -92,7 +90,6 @@ export default class ShowcaseLayout extends React.Component<Props, State> {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const {initialLayout, ...props} = this.props;
     return (
       <div>
         <div>
@@ -108,7 +105,7 @@ export default class ShowcaseLayout extends React.Component<Props, State> {
           Change Compaction Type
         </button>
         <ResponsiveReactGridLayout
-          {...props}
+          {...this.props}
           layouts={this.state.layouts}
           onBreakpointChange={this.onBreakpointChange}
           onLayoutChange={this.onLayoutChange}
@@ -132,7 +129,7 @@ function generateLayout() {
   return _.map(_.range(0, 25), function(item, i) {
     var y = Math.ceil(Math.random() * 4) + 1;
     return {
-      x: (_.random(0, 5) * 2) % 12,
+      x: Math.ceil(Math.random() * 10),
       y: Math.floor(i / 6) * y,
       w: 2,
       h: y,

--- a/test/examples/0-showcase.jsx
+++ b/test/examples/0-showcase.jsx
@@ -129,7 +129,7 @@ function generateLayout() {
   return _.map(_.range(0, 25), function(item, i) {
     var y = Math.ceil(Math.random() * 4) + 1;
     return {
-      x: Math.ceil(Math.random() * 10),
+      x: Math.round(Math.random() * 5) * 2,
       y: Math.floor(i / 6) * y,
       w: 2,
       h: y,

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -3710,7 +3710,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "1",
               "static": false,
               "w": 2,
-              "x": 5,
+              "x": 6,
               "y": 0,
             },
             Object {
@@ -3726,7 +3726,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "3",
               "static": false,
               "w": 2,
-              "x": 1,
+              "x": 0,
               "y": 0,
             },
             Object {
@@ -3734,7 +3734,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "4",
               "static": false,
               "w": 2,
-              "x": 3,
+              "x": 4,
               "y": 0,
             },
             Object {
@@ -3750,7 +3750,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "6",
               "static": false,
               "w": 2,
-              "x": 9,
+              "x": 10,
               "y": 5,
             },
             Object {
@@ -3758,7 +3758,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "7",
               "static": false,
               "w": 2,
-              "x": 1,
+              "x": 2,
               "y": 2,
             },
             Object {
@@ -3774,7 +3774,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "9",
               "static": false,
               "w": 2,
-              "x": 7,
+              "x": 8,
               "y": 4,
             },
             Object {
@@ -3798,7 +3798,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "12",
               "static": false,
               "w": 2,
-              "x": 5,
+              "x": 6,
               "y": 6,
             },
             Object {
@@ -3814,7 +3814,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "14",
               "static": false,
               "w": 2,
-              "x": 1,
+              "x": 0,
               "y": 10,
             },
             Object {
@@ -3822,7 +3822,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "15",
               "static": false,
               "w": 2,
-              "x": 3,
+              "x": 4,
               "y": 4,
             },
             Object {
@@ -3838,7 +3838,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "17",
               "static": false,
               "w": 2,
-              "x": 9,
+              "x": 10,
               "y": 10,
             },
             Object {
@@ -3846,7 +3846,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "18",
               "static": false,
               "w": 2,
-              "x": 1,
+              "x": 2,
               "y": 6,
             },
             Object {
@@ -3862,7 +3862,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "20",
               "static": false,
               "w": 2,
-              "x": 7,
+              "x": 8,
               "y": 12,
             },
             Object {
@@ -3886,7 +3886,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "23",
               "static": false,
               "w": 2,
-              "x": 5,
+              "x": 6,
               "y": 9,
             },
             Object {
@@ -3969,7 +3969,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "1",
                 "static": false,
                 "w": 2,
-                "x": 5,
+                "x": 6,
                 "y": 0,
               },
               Object {
@@ -3985,7 +3985,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "3",
                 "static": false,
                 "w": 2,
-                "x": 1,
+                "x": 0,
                 "y": 0,
               },
               Object {
@@ -3993,7 +3993,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "4",
                 "static": false,
                 "w": 2,
-                "x": 3,
+                "x": 4,
                 "y": 0,
               },
               Object {
@@ -4009,7 +4009,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "6",
                 "static": false,
                 "w": 2,
-                "x": 9,
+                "x": 10,
                 "y": 5,
               },
               Object {
@@ -4017,7 +4017,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "7",
                 "static": false,
                 "w": 2,
-                "x": 1,
+                "x": 2,
                 "y": 2,
               },
               Object {
@@ -4033,7 +4033,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "9",
                 "static": false,
                 "w": 2,
-                "x": 7,
+                "x": 8,
                 "y": 4,
               },
               Object {
@@ -4057,7 +4057,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "12",
                 "static": false,
                 "w": 2,
-                "x": 5,
+                "x": 6,
                 "y": 6,
               },
               Object {
@@ -4073,7 +4073,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "14",
                 "static": false,
                 "w": 2,
-                "x": 1,
+                "x": 0,
                 "y": 10,
               },
               Object {
@@ -4081,7 +4081,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "15",
                 "static": false,
                 "w": 2,
-                "x": 3,
+                "x": 4,
                 "y": 4,
               },
               Object {
@@ -4097,7 +4097,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "17",
                 "static": false,
                 "w": 2,
-                "x": 9,
+                "x": 10,
                 "y": 10,
               },
               Object {
@@ -4105,7 +4105,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "18",
                 "static": false,
                 "w": 2,
-                "x": 1,
+                "x": 2,
                 "y": 6,
               },
               Object {
@@ -4121,7 +4121,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "20",
                 "static": false,
                 "w": 2,
-                "x": 7,
+                "x": 8,
                 "y": 12,
               },
               Object {
@@ -4145,7 +4145,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "23",
                 "static": false,
                 "w": 2,
-                "x": 5,
+                "x": 6,
                 "y": 9,
               },
               Object {

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -4227,7 +4227,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 24,
+                "y": 2,
               },
               Object {
                 "h": 4,
@@ -4242,7 +4242,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 27,
+                "y": 5,
               },
               Object {
                 "h": 5,
@@ -4257,7 +4257,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 2,
+                "y": 21,
               },
               Object {
                 "h": 2,
@@ -4272,7 +4272,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 7,
+                "y": 26,
               },
               Object {
                 "h": 3,
@@ -4287,7 +4287,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 21,
+                "y": 28,
               },
               Object {
                 "h": 5,
@@ -4392,7 +4392,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 56,
+                "y": 49,
               },
               Object {
                 "h": 4,
@@ -4452,7 +4452,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 53,
+                "y": 52,
               },
               Object {
                 "h": 5,
@@ -4482,7 +4482,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 51,
+                "y": 55,
               },
               Object {
                 "h": 3,
@@ -4542,7 +4542,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 49,
+                "y": 57,
               },
               Object {
                 "h": 3,
@@ -4816,7 +4816,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={24}
+              y={2}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -4889,14 +4889,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,960px)",
-                        "OTransform": "translate(0px,960px)",
-                        "WebkitTransform": "translate(0px,960px)",
+                        "MozTransform": "translate(0px,80px)",
+                        "OTransform": "translate(0px,80px)",
+                        "WebkitTransform": "translate(0px,80px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,960px)",
+                        "msTransform": "translate(0px,80px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,960px)",
+                        "transform": "translate(0px,80px)",
                         "width": "0px",
                       }
                     }
@@ -4980,7 +4980,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={27}
+              y={5}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5053,14 +5053,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,1080px)",
-                        "OTransform": "translate(0px,1080px)",
-                        "WebkitTransform": "translate(0px,1080px)",
+                        "MozTransform": "translate(0px,200px)",
+                        "OTransform": "translate(0px,200px)",
+                        "WebkitTransform": "translate(0px,200px)",
                         "height": "150px",
-                        "msTransform": "translate(0px,1080px)",
+                        "msTransform": "translate(0px,200px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,1080px)",
+                        "transform": "translate(0px,200px)",
                         "width": "0px",
                       }
                     }
@@ -5144,7 +5144,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={2}
+              y={21}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5217,14 +5217,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,80px)",
-                        "OTransform": "translate(0px,80px)",
-                        "WebkitTransform": "translate(0px,80px)",
+                        "MozTransform": "translate(0px,840px)",
+                        "OTransform": "translate(0px,840px)",
+                        "WebkitTransform": "translate(0px,840px)",
                         "height": "190px",
-                        "msTransform": "translate(0px,80px)",
+                        "msTransform": "translate(0px,840px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,80px)",
+                        "transform": "translate(0px,840px)",
                         "width": "0px",
                       }
                     }
@@ -5308,7 +5308,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={7}
+              y={26}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5381,14 +5381,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,280px)",
-                        "OTransform": "translate(0px,280px)",
-                        "WebkitTransform": "translate(0px,280px)",
+                        "MozTransform": "translate(0px,1040px)",
+                        "OTransform": "translate(0px,1040px)",
+                        "WebkitTransform": "translate(0px,1040px)",
                         "height": "70px",
-                        "msTransform": "translate(0px,280px)",
+                        "msTransform": "translate(0px,1040px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,280px)",
+                        "transform": "translate(0px,1040px)",
                         "width": "0px",
                       }
                     }
@@ -5472,7 +5472,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={21}
+              y={28}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5545,14 +5545,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,840px)",
-                        "OTransform": "translate(0px,840px)",
-                        "WebkitTransform": "translate(0px,840px)",
+                        "MozTransform": "translate(0px,1120px)",
+                        "OTransform": "translate(0px,1120px)",
+                        "WebkitTransform": "translate(0px,1120px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,840px)",
+                        "msTransform": "translate(0px,1120px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,840px)",
+                        "transform": "translate(0px,1120px)",
                         "width": "0px",
                       }
                     }
@@ -6623,7 +6623,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={56}
+              y={49}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -6696,14 +6696,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2240px)",
-                        "OTransform": "translate(0px,2240px)",
-                        "WebkitTransform": "translate(0px,2240px)",
+                        "MozTransform": "translate(0px,1960px)",
+                        "OTransform": "translate(0px,1960px)",
+                        "WebkitTransform": "translate(0px,1960px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,2240px)",
+                        "msTransform": "translate(0px,1960px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2240px)",
+                        "transform": "translate(0px,1960px)",
                         "width": "0px",
                       }
                     }
@@ -7279,7 +7279,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={53}
+              y={52}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -7352,14 +7352,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2120px)",
-                        "OTransform": "translate(0px,2120px)",
-                        "WebkitTransform": "translate(0px,2120px)",
+                        "MozTransform": "translate(0px,2080px)",
+                        "OTransform": "translate(0px,2080px)",
+                        "WebkitTransform": "translate(0px,2080px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,2120px)",
+                        "msTransform": "translate(0px,2080px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2120px)",
+                        "transform": "translate(0px,2080px)",
                         "width": "0px",
                       }
                     }
@@ -7607,7 +7607,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={51}
+              y={55}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -7680,14 +7680,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2040px)",
-                        "OTransform": "translate(0px,2040px)",
-                        "WebkitTransform": "translate(0px,2040px)",
+                        "MozTransform": "translate(0px,2200px)",
+                        "OTransform": "translate(0px,2200px)",
+                        "WebkitTransform": "translate(0px,2200px)",
                         "height": "70px",
-                        "msTransform": "translate(0px,2040px)",
+                        "msTransform": "translate(0px,2200px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2040px)",
+                        "transform": "translate(0px,2200px)",
                         "width": "0px",
                       }
                     }
@@ -8266,7 +8266,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={49}
+              y={57}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -8339,14 +8339,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,1960px)",
-                        "OTransform": "translate(0px,1960px)",
-                        "WebkitTransform": "translate(0px,1960px)",
+                        "MozTransform": "translate(0px,2280px)",
+                        "OTransform": "translate(0px,2280px)",
+                        "WebkitTransform": "translate(0px,2280px)",
                         "height": "70px",
-                        "msTransform": "translate(0px,1960px)",
+                        "msTransform": "translate(0px,2280px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,1960px)",
+                        "transform": "translate(0px,2280px)",
                         "width": "0px",
                       }
                     }

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -22,21 +22,21 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           "y": 0,
         },
         Object {
-          "h": 3,
+          "h": 2,
           "i": "1",
           "w": 2,
           "x": 2,
           "y": 0,
         },
         Object {
-          "h": 4,
+          "h": 3,
           "i": "2",
           "w": 2,
           "x": 4,
           "y": 0,
         },
         Object {
-          "h": 5,
+          "h": 3,
           "i": "3",
           "w": 2,
           "x": 6,
@@ -57,11 +57,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           "y": 0,
         },
         Object {
-          "h": 5,
+          "h": 4,
           "i": "6",
           "w": 2,
           "x": 0,
-          "y": 5,
+          "y": 4,
         },
         Object {
           "h": 5,
@@ -85,11 +85,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           "y": 5,
         },
         Object {
-          "h": 3,
+          "h": 2,
           "i": "10",
           "w": 2,
           "x": 8,
-          "y": 3,
+          "y": 2,
         },
         Object {
           "h": 2,
@@ -99,46 +99,46 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           "y": 2,
         },
         Object {
-          "h": 3,
+          "h": 2,
           "i": "12",
           "w": 2,
           "x": 0,
-          "y": 6,
+          "y": 4,
         },
         Object {
-          "h": 2,
+          "h": 3,
           "i": "13",
           "w": 2,
           "x": 2,
-          "y": 4,
+          "y": 6,
         },
         Object {
-          "h": 5,
+          "h": 3,
           "i": "14",
           "w": 2,
           "x": 4,
-          "y": 10,
+          "y": 6,
         },
         Object {
-          "h": 5,
+          "h": 3,
           "i": "15",
           "w": 2,
           "x": 6,
-          "y": 10,
+          "y": 6,
         },
         Object {
-          "h": 5,
+          "h": 4,
           "i": "16",
           "w": 2,
           "x": 8,
-          "y": 10,
+          "y": 8,
         },
         Object {
-          "h": 2,
+          "h": 4,
           "i": "17",
           "w": 2,
           "x": 10,
-          "y": 4,
+          "y": 8,
         },
         Object {
           "h": 5,
@@ -148,11 +148,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           "y": 15,
         },
         Object {
-          "h": 2,
+          "h": 5,
           "i": "19",
           "w": 2,
           "x": 2,
-          "y": 6,
+          "y": 15,
         },
       ]
     }
@@ -189,21 +189,21 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             "y": 0,
           },
           Object {
-            "h": 3,
+            "h": 2,
             "i": "1",
             "w": 2,
             "x": 2,
             "y": 0,
           },
           Object {
-            "h": 4,
+            "h": 3,
             "i": "2",
             "w": 2,
             "x": 4,
             "y": 0,
           },
           Object {
-            "h": 5,
+            "h": 3,
             "i": "3",
             "w": 2,
             "x": 6,
@@ -224,11 +224,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             "y": 0,
           },
           Object {
-            "h": 5,
+            "h": 4,
             "i": "6",
             "w": 2,
             "x": 0,
-            "y": 5,
+            "y": 4,
           },
           Object {
             "h": 5,
@@ -252,11 +252,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             "y": 5,
           },
           Object {
-            "h": 3,
+            "h": 2,
             "i": "10",
             "w": 2,
             "x": 8,
-            "y": 3,
+            "y": 2,
           },
           Object {
             "h": 2,
@@ -266,46 +266,46 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             "y": 2,
           },
           Object {
-            "h": 3,
+            "h": 2,
             "i": "12",
             "w": 2,
             "x": 0,
-            "y": 6,
+            "y": 4,
           },
           Object {
-            "h": 2,
+            "h": 3,
             "i": "13",
             "w": 2,
             "x": 2,
-            "y": 4,
+            "y": 6,
           },
           Object {
-            "h": 5,
+            "h": 3,
             "i": "14",
             "w": 2,
             "x": 4,
-            "y": 10,
+            "y": 6,
           },
           Object {
-            "h": 5,
+            "h": 3,
             "i": "15",
             "w": 2,
             "x": 6,
-            "y": 10,
+            "y": 6,
           },
           Object {
-            "h": 5,
+            "h": 4,
             "i": "16",
             "w": 2,
             "x": 8,
-            "y": 10,
+            "y": 8,
           },
           Object {
-            "h": 2,
+            "h": 4,
             "i": "17",
             "w": 2,
             "x": 10,
-            "y": 4,
+            "y": 8,
           },
           Object {
             "h": 5,
@@ -315,11 +315,11 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             "y": 15,
           },
           Object {
-            "h": 2,
+            "h": 5,
             "i": "19",
             "w": 2,
             "x": 2,
-            "y": 6,
+            "y": 15,
           },
         ]
       }
@@ -533,7 +533,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={3}
+          h={2}
           handle=""
           i="1"
           isDraggable={true}
@@ -593,7 +593,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={110}
+              height={70}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -639,7 +639,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(8px,10px)",
                     "OTransform": "translate(8px,10px)",
                     "WebkitTransform": "translate(8px,10px)",
-                    "height": "110px",
+                    "height": "70px",
                     "msTransform": "translate(8px,10px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -697,7 +697,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={4}
+          h={3}
           handle=""
           i="2"
           isDraggable={true}
@@ -757,7 +757,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={150}
+              height={110}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -803,7 +803,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(7px,10px)",
                     "OTransform": "translate(7px,10px)",
                     "WebkitTransform": "translate(7px,10px)",
-                    "height": "150px",
+                    "height": "110px",
                     "msTransform": "translate(7px,10px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -861,7 +861,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={5}
+          h={3}
           handle=""
           i="3"
           isDraggable={true}
@@ -921,7 +921,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={190}
+              height={110}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -967,7 +967,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(5px,10px)",
                     "OTransform": "translate(5px,10px)",
                     "WebkitTransform": "translate(5px,10px)",
-                    "height": "190px",
+                    "height": "110px",
                     "msTransform": "translate(5px,10px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -1353,7 +1353,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={5}
+          h={4}
           handle=""
           i="6"
           isDraggable={true}
@@ -1413,7 +1413,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={190}
+              height={150}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -1459,7 +1459,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(10px,90px)",
                     "OTransform": "translate(10px,90px)",
                     "WebkitTransform": "translate(10px,90px)",
-                    "height": "190px",
+                    "height": "150px",
                     "msTransform": "translate(10px,90px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -1547,7 +1547,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={2}
-          y={5}
+          y={2}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -1620,14 +1620,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(8px,210px)",
-                    "OTransform": "translate(8px,210px)",
-                    "WebkitTransform": "translate(8px,210px)",
+                    "MozTransform": "translate(8px,90px)",
+                    "OTransform": "translate(8px,90px)",
+                    "WebkitTransform": "translate(8px,90px)",
                     "height": "190px",
-                    "msTransform": "translate(8px,210px)",
+                    "msTransform": "translate(8px,90px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(8px,210px)",
+                    "transform": "translate(8px,90px)",
                     "width": "-12px",
                   }
                 }
@@ -1711,7 +1711,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={4}
-          y={4}
+          y={3}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -1784,14 +1784,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(7px,170px)",
-                    "OTransform": "translate(7px,170px)",
-                    "WebkitTransform": "translate(7px,170px)",
+                    "MozTransform": "translate(7px,130px)",
+                    "OTransform": "translate(7px,130px)",
+                    "WebkitTransform": "translate(7px,130px)",
                     "height": "190px",
-                    "msTransform": "translate(7px,170px)",
+                    "msTransform": "translate(7px,130px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(7px,170px)",
+                    "transform": "translate(7px,130px)",
                     "width": "-12px",
                   }
                 }
@@ -1875,7 +1875,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={6}
-          y={5}
+          y={3}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -1948,14 +1948,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(5px,210px)",
-                    "OTransform": "translate(5px,210px)",
-                    "WebkitTransform": "translate(5px,210px)",
+                    "MozTransform": "translate(5px,130px)",
+                    "OTransform": "translate(5px,130px)",
+                    "WebkitTransform": "translate(5px,130px)",
                     "height": "190px",
-                    "msTransform": "translate(5px,210px)",
+                    "msTransform": "translate(5px,130px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(5px,210px)",
+                    "transform": "translate(5px,130px)",
                     "width": "-12px",
                   }
                 }
@@ -2009,7 +2009,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={3}
+          h={2}
           handle=""
           i="10"
           isDraggable={true}
@@ -2069,7 +2069,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={110}
+              height={70}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -2115,7 +2115,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(3px,130px)",
                     "OTransform": "translate(3px,130px)",
                     "WebkitTransform": "translate(3px,130px)",
-                    "height": "110px",
+                    "height": "70px",
                     "msTransform": "translate(3px,130px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -2337,7 +2337,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={3}
+          h={2}
           handle=""
           i="12"
           isDraggable={true}
@@ -2367,7 +2367,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={0}
-          y={7}
+          y={6}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -2397,7 +2397,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={110}
+              height={70}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -2440,14 +2440,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(10px,290px)",
-                    "OTransform": "translate(10px,290px)",
-                    "WebkitTransform": "translate(10px,290px)",
-                    "height": "110px",
-                    "msTransform": "translate(10px,290px)",
+                    "MozTransform": "translate(10px,250px)",
+                    "OTransform": "translate(10px,250px)",
+                    "WebkitTransform": "translate(10px,250px)",
+                    "height": "70px",
+                    "msTransform": "translate(10px,250px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(10px,290px)",
+                    "transform": "translate(10px,250px)",
                     "width": "-12px",
                   }
                 }
@@ -2501,7 +2501,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={2}
+          h={3}
           handle=""
           i="13"
           isDraggable={true}
@@ -2531,7 +2531,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={2}
-          y={3}
+          y={7}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -2561,7 +2561,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={70}
+              height={110}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -2604,14 +2604,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(8px,130px)",
-                    "OTransform": "translate(8px,130px)",
-                    "WebkitTransform": "translate(8px,130px)",
-                    "height": "70px",
-                    "msTransform": "translate(8px,130px)",
+                    "MozTransform": "translate(8px,290px)",
+                    "OTransform": "translate(8px,290px)",
+                    "WebkitTransform": "translate(8px,290px)",
+                    "height": "110px",
+                    "msTransform": "translate(8px,290px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(8px,130px)",
+                    "transform": "translate(8px,290px)",
                     "width": "-12px",
                   }
                 }
@@ -2665,7 +2665,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={5}
+          h={3}
           handle=""
           i="14"
           isDraggable={true}
@@ -2695,7 +2695,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={4}
-          y={9}
+          y={8}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -2725,7 +2725,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={190}
+              height={110}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -2768,14 +2768,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(7px,370px)",
-                    "OTransform": "translate(7px,370px)",
-                    "WebkitTransform": "translate(7px,370px)",
-                    "height": "190px",
-                    "msTransform": "translate(7px,370px)",
+                    "MozTransform": "translate(7px,330px)",
+                    "OTransform": "translate(7px,330px)",
+                    "WebkitTransform": "translate(7px,330px)",
+                    "height": "110px",
+                    "msTransform": "translate(7px,330px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(7px,370px)",
+                    "transform": "translate(7px,330px)",
                     "width": "-12px",
                   }
                 }
@@ -2829,7 +2829,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={5}
+          h={3}
           handle=""
           i="15"
           isDraggable={true}
@@ -2859,7 +2859,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={6}
-          y={10}
+          y={8}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -2889,7 +2889,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={190}
+              height={110}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -2932,14 +2932,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(5px,410px)",
-                    "OTransform": "translate(5px,410px)",
-                    "WebkitTransform": "translate(5px,410px)",
-                    "height": "190px",
-                    "msTransform": "translate(5px,410px)",
+                    "MozTransform": "translate(5px,330px)",
+                    "OTransform": "translate(5px,330px)",
+                    "WebkitTransform": "translate(5px,330px)",
+                    "height": "110px",
+                    "msTransform": "translate(5px,330px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(5px,410px)",
+                    "transform": "translate(5px,330px)",
                     "width": "-12px",
                   }
                 }
@@ -2993,7 +2993,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={5}
+          h={4}
           handle=""
           i="16"
           isDraggable={true}
@@ -3023,7 +3023,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={8}
-          y={6}
+          y={5}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -3053,7 +3053,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={190}
+              height={150}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -3096,14 +3096,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(3px,250px)",
-                    "OTransform": "translate(3px,250px)",
-                    "WebkitTransform": "translate(3px,250px)",
-                    "height": "190px",
-                    "msTransform": "translate(3px,250px)",
+                    "MozTransform": "translate(3px,210px)",
+                    "OTransform": "translate(3px,210px)",
+                    "WebkitTransform": "translate(3px,210px)",
+                    "height": "150px",
+                    "msTransform": "translate(3px,210px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(3px,250px)",
+                    "transform": "translate(3px,210px)",
                     "width": "-12px",
                   }
                 }
@@ -3157,7 +3157,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={2}
+          h={4}
           handle=""
           i="17"
           isDraggable={true}
@@ -3217,7 +3217,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={70}
+              height={150}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -3263,7 +3263,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(2px,250px)",
                     "OTransform": "translate(2px,250px)",
                     "WebkitTransform": "translate(2px,250px)",
-                    "height": "70px",
+                    "height": "150px",
                     "msTransform": "translate(2px,250px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -3351,7 +3351,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
           usePercentages={false}
           w={2}
           x={0}
-          y={10}
+          y={8}
         >
           <DraggableCore
             allowAnyClick={false}
@@ -3424,14 +3424,14 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                 onTouchStart={[Function]}
                 style={
                   Object {
-                    "MozTransform": "translate(10px,410px)",
-                    "OTransform": "translate(10px,410px)",
-                    "WebkitTransform": "translate(10px,410px)",
+                    "MozTransform": "translate(10px,330px)",
+                    "OTransform": "translate(10px,330px)",
+                    "WebkitTransform": "translate(10px,330px)",
                     "height": "190px",
-                    "msTransform": "translate(10px,410px)",
+                    "msTransform": "translate(10px,330px)",
                     "position": "absolute",
                     "touchAction": "none",
-                    "transform": "translate(10px,410px)",
+                    "transform": "translate(10px,330px)",
                     "width": "-12px",
                   }
                 }
@@ -3485,7 +3485,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
             ]
           }
           containerWidth={0}
-          h={2}
+          h={5}
           handle=""
           i="19"
           isDraggable={true}
@@ -3545,7 +3545,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                   20,
                 ]
               }
-              height={70}
+              height={190}
               lockAspectRatio={false}
               maxConstraints={
                 Array [
@@ -3591,7 +3591,7 @@ exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
                     "MozTransform": "translate(8px,410px)",
                     "OTransform": "translate(8px,410px)",
                     "WebkitTransform": "translate(8px,410px)",
-                    "height": "70px",
+                    "height": "190px",
                     "msTransform": "translate(8px,410px)",
                     "position": "absolute",
                     "touchAction": "none",
@@ -3698,11 +3698,11 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
         Object {
           "lg": Array [
             Object {
-              "h": 3,
+              "h": 2,
               "i": "0",
               "static": false,
               "w": 2,
-              "x": 1,
+              "x": 2,
               "y": 0,
             },
             Object {
@@ -3710,7 +3710,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "1",
               "static": false,
               "w": 2,
-              "x": 7,
+              "x": 5,
               "y": 0,
             },
             Object {
@@ -3718,31 +3718,31 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "2",
               "static": false,
               "w": 2,
-              "x": 9,
+              "x": 8,
               "y": 0,
             },
             Object {
-              "h": 2,
+              "h": 5,
               "i": "3",
               "static": false,
               "w": 2,
-              "x": 6,
-              "y": 0,
-            },
-            Object {
-              "h": 4,
-              "i": "4",
-              "static": true,
-              "w": 2,
-              "x": 5,
+              "x": 1,
               "y": 0,
             },
             Object {
               "h": 2,
+              "i": "4",
+              "static": false,
+              "w": 2,
+              "x": 3,
+              "y": 0,
+            },
+            Object {
+              "h": 3,
               "i": "5",
               "static": false,
               "w": 2,
-              "x": 8,
+              "x": 6,
               "y": 0,
             },
             Object {
@@ -3750,48 +3750,48 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "i": "6",
               "static": false,
               "w": 2,
-              "x": 3,
+              "x": 9,
               "y": 5,
             },
             Object {
-              "h": 4,
+              "h": 2,
               "i": "7",
+              "static": false,
+              "w": 2,
+              "x": 1,
+              "y": 2,
+            },
+            Object {
+              "h": 3,
+              "i": "8",
+              "static": false,
+              "w": 2,
+              "x": 4,
+              "y": 3,
+            },
+            Object {
+              "h": 4,
+              "i": "9",
               "static": false,
               "w": 2,
               "x": 7,
               "y": 4,
             },
             Object {
-              "h": 2,
-              "i": "8",
-              "static": false,
-              "w": 2,
-              "x": 10,
-              "y": 2,
-            },
-            Object {
-              "h": 2,
-              "i": "9",
-              "static": false,
-              "w": 2,
-              "x": 10,
-              "y": 2,
-            },
-            Object {
-              "h": 4,
+              "h": 5,
               "i": "10",
-              "static": false,
+              "static": true,
               "w": 2,
-              "x": 5,
-              "y": 4,
+              "x": 10,
+              "y": 5,
             },
             Object {
-              "h": 4,
+              "h": 2,
               "i": "11",
               "static": false,
               "w": 2,
-              "x": 8,
-              "y": 4,
+              "x": 2,
+              "y": 2,
             },
             Object {
               "h": 3,
@@ -3802,100 +3802,100 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               "y": 6,
             },
             Object {
-              "h": 3,
+              "h": 4,
               "i": "13",
               "static": false,
               "w": 2,
-              "x": 9,
-              "y": 6,
+              "x": 8,
+              "y": 8,
             },
             Object {
-              "h": 3,
+              "h": 5,
               "i": "14",
               "static": false,
               "w": 2,
-              "x": 10,
-              "y": 6,
+              "x": 1,
+              "y": 10,
             },
             Object {
               "h": 2,
               "i": "15",
               "static": false,
               "w": 2,
-              "x": 2,
+              "x": 3,
               "y": 4,
             },
             Object {
-              "h": 4,
+              "h": 3,
               "i": "16",
               "static": false,
               "w": 2,
-              "x": 5,
-              "y": 8,
+              "x": 6,
+              "y": 6,
             },
             Object {
-              "h": 3,
+              "h": 5,
               "i": "17",
               "static": false,
               "w": 2,
-              "x": 3,
-              "y": 6,
+              "x": 9,
+              "y": 10,
             },
             Object {
-              "h": 5,
+              "h": 2,
               "i": "18",
               "static": false,
               "w": 2,
-              "x": 9,
-              "y": 15,
-            },
-            Object {
-              "h": 4,
-              "i": "19",
-              "static": true,
-              "w": 2,
-              "x": 10,
-              "y": 12,
-            },
-            Object {
-              "h": 2,
-              "i": "20",
-              "static": false,
-              "w": 2,
-              "x": 10,
+              "x": 1,
               "y": 6,
             },
             Object {
-              "h": 4,
-              "i": "21",
+              "h": 3,
+              "i": "19",
               "static": false,
               "w": 2,
-              "x": 1,
-              "y": 12,
+              "x": 4,
+              "y": 9,
             },
             Object {
               "h": 4,
-              "i": "22",
+              "i": "20",
               "static": false,
               "w": 2,
-              "x": 10,
+              "x": 7,
               "y": 12,
             },
             Object {
               "h": 5,
-              "i": "23",
-              "static": false,
+              "i": "21",
+              "static": true,
               "w": 2,
-              "x": 6,
+              "x": 10,
               "y": 15,
             },
             Object {
               "h": 2,
+              "i": "22",
+              "static": false,
+              "w": 2,
+              "x": 2,
+              "y": 6,
+            },
+            Object {
+              "h": 3,
+              "i": "23",
+              "static": false,
+              "w": 2,
+              "x": 5,
+              "y": 9,
+            },
+            Object {
+              "h": 4,
               "i": "24",
               "static": false,
               "w": 2,
-              "x": 3,
-              "y": 8,
+              "x": 8,
+              "y": 16,
             },
           ],
         }
@@ -3957,11 +3957,11 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
           Object {
             "lg": Array [
               Object {
-                "h": 3,
+                "h": 2,
                 "i": "0",
                 "static": false,
                 "w": 2,
-                "x": 1,
+                "x": 2,
                 "y": 0,
               },
               Object {
@@ -3969,7 +3969,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "1",
                 "static": false,
                 "w": 2,
-                "x": 7,
+                "x": 5,
                 "y": 0,
               },
               Object {
@@ -3977,31 +3977,31 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "2",
                 "static": false,
                 "w": 2,
-                "x": 9,
+                "x": 8,
                 "y": 0,
               },
               Object {
-                "h": 2,
+                "h": 5,
                 "i": "3",
                 "static": false,
                 "w": 2,
-                "x": 6,
-                "y": 0,
-              },
-              Object {
-                "h": 4,
-                "i": "4",
-                "static": true,
-                "w": 2,
-                "x": 5,
+                "x": 1,
                 "y": 0,
               },
               Object {
                 "h": 2,
+                "i": "4",
+                "static": false,
+                "w": 2,
+                "x": 3,
+                "y": 0,
+              },
+              Object {
+                "h": 3,
                 "i": "5",
                 "static": false,
                 "w": 2,
-                "x": 8,
+                "x": 6,
                 "y": 0,
               },
               Object {
@@ -4009,48 +4009,48 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "i": "6",
                 "static": false,
                 "w": 2,
-                "x": 3,
+                "x": 9,
                 "y": 5,
               },
               Object {
-                "h": 4,
+                "h": 2,
                 "i": "7",
+                "static": false,
+                "w": 2,
+                "x": 1,
+                "y": 2,
+              },
+              Object {
+                "h": 3,
+                "i": "8",
+                "static": false,
+                "w": 2,
+                "x": 4,
+                "y": 3,
+              },
+              Object {
+                "h": 4,
+                "i": "9",
                 "static": false,
                 "w": 2,
                 "x": 7,
                 "y": 4,
               },
               Object {
-                "h": 2,
-                "i": "8",
-                "static": false,
-                "w": 2,
-                "x": 10,
-                "y": 2,
-              },
-              Object {
-                "h": 2,
-                "i": "9",
-                "static": false,
-                "w": 2,
-                "x": 10,
-                "y": 2,
-              },
-              Object {
-                "h": 4,
+                "h": 5,
                 "i": "10",
-                "static": false,
+                "static": true,
                 "w": 2,
-                "x": 5,
-                "y": 4,
+                "x": 10,
+                "y": 5,
               },
               Object {
-                "h": 4,
+                "h": 2,
                 "i": "11",
                 "static": false,
                 "w": 2,
-                "x": 8,
-                "y": 4,
+                "x": 2,
+                "y": 2,
               },
               Object {
                 "h": 3,
@@ -4061,100 +4061,100 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "y": 6,
               },
               Object {
-                "h": 3,
+                "h": 4,
                 "i": "13",
                 "static": false,
                 "w": 2,
-                "x": 9,
-                "y": 6,
+                "x": 8,
+                "y": 8,
               },
               Object {
-                "h": 3,
+                "h": 5,
                 "i": "14",
                 "static": false,
                 "w": 2,
-                "x": 10,
-                "y": 6,
+                "x": 1,
+                "y": 10,
               },
               Object {
                 "h": 2,
                 "i": "15",
                 "static": false,
                 "w": 2,
-                "x": 2,
+                "x": 3,
                 "y": 4,
               },
               Object {
-                "h": 4,
+                "h": 3,
                 "i": "16",
                 "static": false,
                 "w": 2,
-                "x": 5,
-                "y": 8,
+                "x": 6,
+                "y": 6,
               },
               Object {
-                "h": 3,
+                "h": 5,
                 "i": "17",
                 "static": false,
                 "w": 2,
-                "x": 3,
-                "y": 6,
+                "x": 9,
+                "y": 10,
               },
               Object {
-                "h": 5,
+                "h": 2,
                 "i": "18",
                 "static": false,
                 "w": 2,
-                "x": 9,
-                "y": 15,
-              },
-              Object {
-                "h": 4,
-                "i": "19",
-                "static": true,
-                "w": 2,
-                "x": 10,
-                "y": 12,
-              },
-              Object {
-                "h": 2,
-                "i": "20",
-                "static": false,
-                "w": 2,
-                "x": 10,
+                "x": 1,
                 "y": 6,
               },
               Object {
-                "h": 4,
-                "i": "21",
+                "h": 3,
+                "i": "19",
                 "static": false,
                 "w": 2,
-                "x": 1,
-                "y": 12,
+                "x": 4,
+                "y": 9,
               },
               Object {
                 "h": 4,
-                "i": "22",
+                "i": "20",
                 "static": false,
                 "w": 2,
-                "x": 10,
+                "x": 7,
                 "y": 12,
               },
               Object {
                 "h": 5,
-                "i": "23",
-                "static": false,
+                "i": "21",
+                "static": true,
                 "w": 2,
-                "x": 6,
+                "x": 10,
                 "y": 15,
               },
               Object {
                 "h": 2,
+                "i": "22",
+                "static": false,
+                "w": 2,
+                "x": 2,
+                "y": 6,
+              },
+              Object {
+                "h": 3,
+                "i": "23",
+                "static": false,
+                "w": 2,
+                "x": 5,
+                "y": 9,
+              },
+              Object {
+                "h": 4,
                 "i": "24",
                 "static": false,
                 "w": 2,
-                "x": 3,
-                "y": 8,
+                "x": 8,
+                "y": 16,
               },
             ],
           }
@@ -4200,7 +4200,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
           layout={
             Array [
               Object {
-                "h": 3,
+                "h": 2,
                 "i": "0",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4227,7 +4227,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 12,
+                "y": 24,
               },
               Object {
                 "h": 4,
@@ -4242,10 +4242,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 15,
+                "y": 27,
               },
               Object {
-                "h": 2,
+                "h": 5,
                 "i": "3",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4257,10 +4257,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 8,
+                "y": 2,
               },
               Object {
-                "h": 4,
+                "h": 2,
                 "i": "4",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4269,13 +4269,13 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "minH": undefined,
                 "minW": undefined,
                 "moved": false,
-                "static": true,
+                "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 4,
+                "y": 7,
               },
               Object {
-                "h": 2,
+                "h": 3,
                 "i": "5",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4287,7 +4287,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 10,
+                "y": 21,
               },
               Object {
                 "h": 5,
@@ -4302,11 +4302,41 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 42,
+                "y": 44,
+              },
+              Object {
+                "h": 2,
+                "i": "7",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 31,
+              },
+              Object {
+                "h": 3,
+                "i": "8",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 35,
               },
               Object {
                 "h": 4,
-                "i": "7",
+                "i": "9",
                 "isDraggable": undefined,
                 "isResizable": undefined,
                 "maxH": undefined,
@@ -4320,37 +4350,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "y": 38,
               },
               Object {
-                "h": 2,
-                "i": "8",
-                "isDraggable": undefined,
-                "isResizable": undefined,
-                "maxH": undefined,
-                "maxW": undefined,
-                "minH": undefined,
-                "minW": undefined,
-                "moved": false,
-                "static": false,
-                "w": 2,
-                "x": 0,
-                "y": 24,
-              },
-              Object {
-                "h": 2,
-                "i": "9",
-                "isDraggable": undefined,
-                "isResizable": undefined,
-                "maxH": undefined,
-                "maxW": undefined,
-                "minH": undefined,
-                "minW": undefined,
-                "moved": false,
-                "static": false,
-                "w": 2,
-                "x": 0,
-                "y": 26,
-              },
-              Object {
-                "h": 4,
+                "h": 5,
                 "i": "10",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4359,13 +4359,13 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "minH": undefined,
                 "minW": undefined,
                 "moved": false,
-                "static": false,
+                "static": true,
                 "w": 2,
                 "x": 0,
-                "y": 30,
+                "y": 10,
               },
               Object {
-                "h": 4,
+                "h": 2,
                 "i": "11",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4377,7 +4377,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 34,
+                "y": 33,
               },
               Object {
                 "h": 3,
@@ -4392,10 +4392,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 53,
+                "y": 56,
               },
               Object {
-                "h": 3,
+                "h": 4,
                 "i": "13",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4407,10 +4407,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 47,
+                "y": 59,
               },
               Object {
-                "h": 3,
+                "h": 5,
                 "i": "14",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4422,7 +4422,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 50,
+                "y": 69,
               },
               Object {
                 "h": 2,
@@ -4437,10 +4437,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 28,
+                "y": 42,
               },
               Object {
-                "h": 4,
+                "h": 3,
                 "i": "16",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4452,10 +4452,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 61,
+                "y": 53,
               },
               Object {
-                "h": 3,
+                "h": 5,
                 "i": "17",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4467,10 +4467,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 58,
+                "y": 74,
               },
               Object {
-                "h": 5,
+                "h": 2,
                 "i": "18",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4482,10 +4482,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 75,
+                "y": 51,
               },
               Object {
-                "h": 4,
+                "h": 3,
                 "i": "19",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4494,13 +4494,13 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "minH": undefined,
                 "minW": undefined,
                 "moved": false,
-                "static": true,
+                "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 20,
+                "y": 63,
               },
               Object {
-                "h": 2,
+                "h": 4,
                 "i": "20",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4512,10 +4512,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 56,
+                "y": 79,
               },
               Object {
-                "h": 4,
+                "h": 5,
                 "i": "21",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4524,13 +4524,13 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "minH": undefined,
                 "minW": undefined,
                 "moved": false,
-                "static": false,
+                "static": true,
                 "w": 2,
                 "x": 0,
-                "y": 67,
+                "y": 16,
               },
               Object {
-                "h": 4,
+                "h": 2,
                 "i": "22",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4542,10 +4542,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 71,
+                "y": 49,
               },
               Object {
-                "h": 5,
+                "h": 3,
                 "i": "23",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4557,10 +4557,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 80,
+                "y": 66,
               },
               Object {
-                "h": 2,
+                "h": 4,
                 "i": "24",
                 "isDraggable": undefined,
                 "isResizable": undefined,
@@ -4572,7 +4572,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 "static": false,
                 "w": 2,
                 "x": 0,
-                "y": 65,
+                "y": 83,
               },
             ]
           }
@@ -4607,7 +4607,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
             onDrop={[Function]}
             style={
               Object {
-                "height": "3390px",
+                "height": "3470px",
               }
             }
           >
@@ -4622,7 +4622,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={3}
+              h={2}
               handle=""
               i="0"
               isDraggable={true}
@@ -4682,7 +4682,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                       20,
                     ]
                   }
-                  height={110}
+                  height={70}
                   lockAspectRatio={false}
                   maxConstraints={
                     Array [
@@ -4728,7 +4728,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                         "MozTransform": "translate(0px,0px)",
                         "OTransform": "translate(0px,0px)",
                         "WebkitTransform": "translate(0px,0px)",
-                        "height": "110px",
+                        "height": "70px",
                         "msTransform": "translate(0px,0px)",
                         "position": "absolute",
                         "touchAction": "none",
@@ -4816,7 +4816,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={12}
+              y={24}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -4889,14 +4889,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,480px)",
-                        "OTransform": "translate(0px,480px)",
-                        "WebkitTransform": "translate(0px,480px)",
+                        "MozTransform": "translate(0px,960px)",
+                        "OTransform": "translate(0px,960px)",
+                        "WebkitTransform": "translate(0px,960px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,480px)",
+                        "msTransform": "translate(0px,960px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,480px)",
+                        "transform": "translate(0px,960px)",
                         "width": "0px",
                       }
                     }
@@ -4980,7 +4980,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={15}
+              y={27}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5053,14 +5053,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,600px)",
-                        "OTransform": "translate(0px,600px)",
-                        "WebkitTransform": "translate(0px,600px)",
+                        "MozTransform": "translate(0px,1080px)",
+                        "OTransform": "translate(0px,1080px)",
+                        "WebkitTransform": "translate(0px,1080px)",
                         "height": "150px",
-                        "msTransform": "translate(0px,600px)",
+                        "msTransform": "translate(0px,1080px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,600px)",
+                        "transform": "translate(0px,1080px)",
                         "width": "0px",
                       }
                     }
@@ -5114,7 +5114,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={2}
+              h={5}
               handle=""
               i="3"
               isDraggable={true}
@@ -5144,7 +5144,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={8}
+              y={2}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5174,7 +5174,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                       20,
                     ]
                   }
-                  height={70}
+                  height={190}
                   lockAspectRatio={false}
                   maxConstraints={
                     Array [
@@ -5217,14 +5217,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,320px)",
-                        "OTransform": "translate(0px,320px)",
-                        "WebkitTransform": "translate(0px,320px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,320px)",
+                        "MozTransform": "translate(0px,80px)",
+                        "OTransform": "translate(0px,80px)",
+                        "WebkitTransform": "translate(0px,80px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,80px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,320px)",
+                        "transform": "translate(0px,80px)",
                         "width": "0px",
                       }
                     }
@@ -5278,179 +5278,12 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={4}
-              handle=""
-              i="4"
-              isDraggable={false}
-              isResizable={false}
-              key=".$4"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={true}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={4}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={true}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  className="react-resizable-hide"
-                  draggableOpts={
-                    Object {
-                      "disabled": true,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={150}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
-                    key="4"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,160px)",
-                        "OTransform": "translate(0px,160px)",
-                        "WebkitTransform": "translate(0px,160px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,160px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,160px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                      title="This item is static and cannot be removed or resized."
-                    >
-                      Static - 
-                      4
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={true}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
               h={2}
               handle=""
-              i="5"
+              i="4"
               isDraggable={true}
               isResizable={true}
-              key=".$5"
+              key=".$4"
               margin={
                 Array [
                   10,
@@ -5475,7 +5308,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={10}
+              y={7}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5541,6 +5374,170 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 >
                   <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="4"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,280px)",
+                        "OTransform": "translate(0px,280px)",
+                        "WebkitTransform": "translate(0px,280px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,280px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,280px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      4
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="5"
+              isDraggable={true}
+              isResizable={true}
+              key=".$5"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={21}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
                     key="5"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -5548,14 +5545,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,400px)",
-                        "OTransform": "translate(0px,400px)",
-                        "WebkitTransform": "translate(0px,400px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,400px)",
+                        "MozTransform": "translate(0px,840px)",
+                        "OTransform": "translate(0px,840px)",
+                        "WebkitTransform": "translate(0px,840px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,840px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,400px)",
+                        "transform": "translate(0px,840px)",
                         "width": "0px",
                       }
                     }
@@ -5639,7 +5636,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={42}
+              y={44}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -5712,14 +5709,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,1680px)",
-                        "OTransform": "translate(0px,1680px)",
-                        "WebkitTransform": "translate(0px,1680px)",
+                        "MozTransform": "translate(0px,1760px)",
+                        "OTransform": "translate(0px,1760px)",
+                        "WebkitTransform": "translate(0px,1760px)",
                         "height": "190px",
-                        "msTransform": "translate(0px,1680px)",
+                        "msTransform": "translate(0px,1760px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,1680px)",
+                        "transform": "translate(0px,1760px)",
                         "width": "0px",
                       }
                     }
@@ -5773,12 +5770,340 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={4}
+              h={2}
               handle=""
               i="7"
               isDraggable={true}
               isResizable={true}
               key=".$7"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={31}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="7"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1240px)",
+                        "OTransform": "translate(0px,1240px)",
+                        "WebkitTransform": "translate(0px,1240px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1240px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1240px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      7
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="8"
+              isDraggable={true}
+              isResizable={true}
+              key=".$8"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={35}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="8"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1400px)",
+                        "OTransform": "translate(0px,1400px)",
+                        "WebkitTransform": "translate(0px,1400px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,1400px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1400px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      8
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="9"
+              isDraggable={true}
+              isResizable={true}
+              key=".$9"
               margin={
                 Array [
                   10,
@@ -5869,7 +6194,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 >
                   <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="7"
+                    key="9"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
                     onTouchEnd={[Function]}
@@ -5884,334 +6209,6 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                         "position": "absolute",
                         "touchAction": "none",
                         "transform": "translate(0px,1520px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      7
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={2}
-              handle=""
-              i="8"
-              isDraggable={true}
-              isResizable={true}
-              key=".$8"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={24}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={70}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="8"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,960px)",
-                        "OTransform": "translate(0px,960px)",
-                        "WebkitTransform": "translate(0px,960px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,960px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,960px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      8
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={2}
-              handle=""
-              i="9"
-              isDraggable={true}
-              isResizable={true}
-              key=".$9"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={26}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={70}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="9"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,1040px)",
-                        "OTransform": "translate(0px,1040px)",
-                        "WebkitTransform": "translate(0px,1040px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,1040px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,1040px)",
                         "width": "0px",
                       }
                     }
@@ -6265,11 +6262,11 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={4}
+              h={5}
               handle=""
               i="10"
-              isDraggable={true}
-              isResizable={true}
+              isDraggable={false}
+              isResizable={false}
               key=".$10"
               margin={
                 Array [
@@ -6289,18 +6286,18 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               onResizeStart={[Function]}
               onResizeStop={[Function]}
               rowHeight={30}
-              static={false}
+              static={true}
               transformScale={1}
               useCSSTransforms={true}
               usePercentages={false}
               w={2}
               x={0}
-              y={30}
+              y={10}
             >
               <DraggableCore
                 allowAnyClick={false}
                 cancel=".react-resizable-handle"
-                disabled={false}
+                disabled={true}
                 enableUserSelectHack={true}
                 grid={null}
                 handle=""
@@ -6314,9 +6311,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               >
                 <Resizable
                   axis="both"
+                  className="react-resizable-hide"
                   draggableOpts={
                     Object {
-                      "disabled": false,
+                      "disabled": true,
                     }
                   }
                   handleSize={
@@ -6325,7 +6323,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                       20,
                     ]
                   }
-                  height={150}
+                  height={190}
                   lockAspectRatio={false}
                   maxConstraints={
                     Array [
@@ -6360,7 +6358,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                   width={0}
                 >
                   <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
                     key="10"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -6368,27 +6366,29 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,1200px)",
-                        "OTransform": "translate(0px,1200px)",
-                        "WebkitTransform": "translate(0px,1200px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,1200px)",
+                        "MozTransform": "translate(0px,400px)",
+                        "OTransform": "translate(0px,400px)",
+                        "WebkitTransform": "translate(0px,400px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,400px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,1200px)",
+                        "transform": "translate(0px,400px)",
                         "width": "0px",
                       }
                     }
                   >
                     <span
                       className="text"
+                      title="This item is static and cannot be removed or resized."
                     >
+                      Static - 
                       10
                     </span>
                     <DraggableCore
                       allowAnyClick={false}
                       cancel={null}
-                      disabled={false}
+                      disabled={true}
                       enableUserSelectHack={true}
                       grid={null}
                       handle={null}
@@ -6429,7 +6429,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={4}
+              h={2}
               handle=""
               i="11"
               isDraggable={true}
@@ -6459,7 +6459,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={34}
+              y={33}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -6489,7 +6489,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                       20,
                     ]
                   }
-                  height={150}
+                  height={70}
                   lockAspectRatio={false}
                   maxConstraints={
                     Array [
@@ -6532,14 +6532,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,1360px)",
-                        "OTransform": "translate(0px,1360px)",
-                        "WebkitTransform": "translate(0px,1360px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,1360px)",
+                        "MozTransform": "translate(0px,1320px)",
+                        "OTransform": "translate(0px,1320px)",
+                        "WebkitTransform": "translate(0px,1320px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1320px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,1360px)",
+                        "transform": "translate(0px,1320px)",
                         "width": "0px",
                       }
                     }
@@ -6599,6 +6599,662 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               isDraggable={true}
               isResizable={true}
               key=".$12"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={56}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="12"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2240px)",
+                        "OTransform": "translate(0px,2240px)",
+                        "WebkitTransform": "translate(0px,2240px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,2240px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2240px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      12
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="13"
+              isDraggable={true}
+              isResizable={true}
+              key=".$13"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={59}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="13"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2360px)",
+                        "OTransform": "translate(0px,2360px)",
+                        "WebkitTransform": "translate(0px,2360px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,2360px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2360px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      13
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={5}
+              handle=""
+              i="14"
+              isDraggable={true}
+              isResizable={true}
+              key=".$14"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={69}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={190}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="14"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2760px)",
+                        "OTransform": "translate(0px,2760px)",
+                        "WebkitTransform": "translate(0px,2760px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,2760px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2760px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      14
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="15"
+              isDraggable={true}
+              isResizable={true}
+              key=".$15"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={42}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="15"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1680px)",
+                        "OTransform": "translate(0px,1680px)",
+                        "WebkitTransform": "translate(0px,1680px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1680px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1680px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      15
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="16"
+              isDraggable={true}
+              isResizable={true}
+              key=".$16"
               margin={
                 Array [
                   10,
@@ -6689,7 +7345,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 >
                   <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="12"
+                    key="16"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
                     onTouchEnd={[Function]}
@@ -6704,662 +7360,6 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                         "position": "absolute",
                         "touchAction": "none",
                         "transform": "translate(0px,2120px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      12
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={3}
-              handle=""
-              i="13"
-              isDraggable={true}
-              isResizable={true}
-              key=".$13"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={47}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={110}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="13"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,1880px)",
-                        "OTransform": "translate(0px,1880px)",
-                        "WebkitTransform": "translate(0px,1880px)",
-                        "height": "110px",
-                        "msTransform": "translate(0px,1880px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,1880px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      13
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={3}
-              handle=""
-              i="14"
-              isDraggable={true}
-              isResizable={true}
-              key=".$14"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={50}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={110}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="14"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,2000px)",
-                        "OTransform": "translate(0px,2000px)",
-                        "WebkitTransform": "translate(0px,2000px)",
-                        "height": "110px",
-                        "msTransform": "translate(0px,2000px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,2000px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      14
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={2}
-              handle=""
-              i="15"
-              isDraggable={true}
-              isResizable={true}
-              key=".$15"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={28}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={70}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="15"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,1120px)",
-                        "OTransform": "translate(0px,1120px)",
-                        "WebkitTransform": "translate(0px,1120px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,1120px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,1120px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      15
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={4}
-              handle=""
-              i="16"
-              isDraggable={true}
-              isResizable={true}
-              key=".$16"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={61}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={150}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="16"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,2440px)",
-                        "OTransform": "translate(0px,2440px)",
-                        "WebkitTransform": "translate(0px,2440px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,2440px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,2440px)",
                         "width": "0px",
                       }
                     }
@@ -7413,7 +7413,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={3}
+              h={5}
               handle=""
               i="17"
               isDraggable={true}
@@ -7443,7 +7443,335 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={58}
+              y={74}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={190}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="17"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2960px)",
+                        "OTransform": "translate(0px,2960px)",
+                        "WebkitTransform": "translate(0px,2960px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,2960px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2960px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      17
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="18"
+              isDraggable={true}
+              isResizable={true}
+              key=".$18"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={51}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="18"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2040px)",
+                        "OTransform": "translate(0px,2040px)",
+                        "WebkitTransform": "translate(0px,2040px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,2040px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2040px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      18
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="19"
+              isDraggable={true}
+              isResizable={true}
+              key=".$19"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={63}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -7509,21 +7837,21 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 >
                   <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="17"
+                    key="19"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
                     onTouchEnd={[Function]}
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2320px)",
-                        "OTransform": "translate(0px,2320px)",
-                        "WebkitTransform": "translate(0px,2320px)",
+                        "MozTransform": "translate(0px,2520px)",
+                        "OTransform": "translate(0px,2520px)",
+                        "WebkitTransform": "translate(0px,2520px)",
                         "height": "110px",
-                        "msTransform": "translate(0px,2320px)",
+                        "msTransform": "translate(0px,2520px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2320px)",
+                        "transform": "translate(0px,2520px)",
                         "width": "0px",
                       }
                     }
@@ -7531,171 +7859,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     <span
                       className="text"
                     >
-                      17
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={5}
-              handle=""
-              i="18"
-              isDraggable={true}
-              isResizable={true}
-              key=".$18"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={75}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={190}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="18"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,3000px)",
-                        "OTransform": "translate(0px,3000px)",
-                        "WebkitTransform": "translate(0px,3000px)",
-                        "height": "190px",
-                        "msTransform": "translate(0px,3000px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,3000px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      18
+                      19
                     </span>
                     <DraggableCore
                       allowAnyClick={false}
@@ -7743,10 +7907,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               containerWidth={0}
               h={4}
               handle=""
-              i="19"
-              isDraggable={false}
-              isResizable={false}
-              key=".$19"
+              i="20"
+              isDraggable={true}
+              isResizable={true}
+              key=".$20"
               margin={
                 Array [
                   10,
@@ -7765,18 +7929,18 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               onResizeStart={[Function]}
               onResizeStop={[Function]}
               rowHeight={30}
-              static={true}
+              static={false}
               transformScale={1}
               useCSSTransforms={true}
               usePercentages={false}
               w={2}
               x={0}
-              y={20}
+              y={79}
             >
               <DraggableCore
                 allowAnyClick={false}
                 cancel=".react-resizable-handle"
-                disabled={true}
+                disabled={false}
                 enableUserSelectHack={true}
                 grid={null}
                 handle=""
@@ -7790,10 +7954,9 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               >
                 <Resizable
                   axis="both"
-                  className="react-resizable-hide"
                   draggableOpts={
                     Object {
-                      "disabled": true,
+                      "disabled": false,
                     }
                   }
                   handleSize={
@@ -7837,172 +8000,6 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                   width={0}
                 >
                   <div
-                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
-                    key="19"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,800px)",
-                        "OTransform": "translate(0px,800px)",
-                        "WebkitTransform": "translate(0px,800px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,800px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,800px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                      title="This item is static and cannot be removed or resized."
-                    >
-                      Static - 
-                      19
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={true}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={2}
-              handle=""
-              i="20"
-              isDraggable={true}
-              isResizable={true}
-              key=".$20"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={56}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={70}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
                     key="20"
                     onMouseDown={[Function]}
@@ -8011,14 +8008,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2240px)",
-                        "OTransform": "translate(0px,2240px)",
-                        "WebkitTransform": "translate(0px,2240px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,2240px)",
+                        "MozTransform": "translate(0px,3160px)",
+                        "OTransform": "translate(0px,3160px)",
+                        "WebkitTransform": "translate(0px,3160px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,3160px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2240px)",
+                        "transform": "translate(0px,3160px)",
                         "width": "0px",
                       }
                     }
@@ -8072,11 +8069,11 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 ]
               }
               containerWidth={0}
-              h={4}
+              h={5}
               handle=""
               i="21"
-              isDraggable={true}
-              isResizable={true}
+              isDraggable={false}
+              isResizable={false}
               key=".$21"
               margin={
                 Array [
@@ -8096,18 +8093,18 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               onResizeStart={[Function]}
               onResizeStop={[Function]}
               rowHeight={30}
-              static={false}
+              static={true}
               transformScale={1}
               useCSSTransforms={true}
               usePercentages={false}
               w={2}
               x={0}
-              y={67}
+              y={16}
             >
               <DraggableCore
                 allowAnyClick={false}
                 cancel=".react-resizable-handle"
-                disabled={false}
+                disabled={true}
                 enableUserSelectHack={true}
                 grid={null}
                 handle=""
@@ -8121,337 +8118,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               >
                 <Resizable
                   axis="both"
+                  className="react-resizable-hide"
                   draggableOpts={
                     Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={150}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="21"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,2680px)",
-                        "OTransform": "translate(0px,2680px)",
-                        "WebkitTransform": "translate(0px,2680px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,2680px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,2680px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      21
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={4}
-              handle=""
-              i="22"
-              isDraggable={true}
-              isResizable={true}
-              key=".$22"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={71}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
-                    }
-                  }
-                  handleSize={
-                    Array [
-                      20,
-                      20,
-                    ]
-                  }
-                  height={150}
-                  lockAspectRatio={false}
-                  maxConstraints={
-                    Array [
-                      0,
-                      Infinity,
-                    ]
-                  }
-                  minConstraints={
-                    Array [
-                      -5,
-                      30,
-                    ]
-                  }
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onResize={[Function]}
-                  onResizeStart={[Function]}
-                  onResizeStop={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
-                  resizeHandles={
-                    Array [
-                      "se",
-                    ]
-                  }
-                  style={
-                    Object {
-                      "touchAction": "none",
-                    }
-                  }
-                  transformScale={1}
-                  width={0}
-                >
-                  <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="22"
-                    onMouseDown={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    style={
-                      Object {
-                        "MozTransform": "translate(0px,2840px)",
-                        "OTransform": "translate(0px,2840px)",
-                        "WebkitTransform": "translate(0px,2840px)",
-                        "height": "150px",
-                        "msTransform": "translate(0px,2840px)",
-                        "position": "absolute",
-                        "touchAction": "none",
-                        "transform": "translate(0px,2840px)",
-                        "width": "0px",
-                      }
-                    }
-                  >
-                    <span
-                      className="text"
-                    >
-                      22
-                    </span>
-                    <DraggableCore
-                      allowAnyClick={false}
-                      cancel={null}
-                      disabled={false}
-                      enableUserSelectHack={true}
-                      grid={null}
-                      handle={null}
-                      key="resizableHandle-se"
-                      offsetParent={null}
-                      onDrag={[Function]}
-                      onMouseDown={[Function]}
-                      onStart={[Function]}
-                      onStop={[Function]}
-                      scale={1}
-                      transform={null}
-                    >
-                      <span
-                        className="react-resizable-handle react-resizable-handle-se"
-                        onMouseDown={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchStart={[Function]}
-                        style={
-                          Object {
-                            "touchAction": "none",
-                          }
-                        }
-                      />
-                    </DraggableCore>
-                  </div>
-                </Resizable>
-              </DraggableCore>
-            </GridItem>
-            <GridItem
-              cancel=""
-              className=""
-              cols={2}
-              containerPadding={
-                Array [
-                  0,
-                  0,
-                ]
-              }
-              containerWidth={0}
-              h={5}
-              handle=""
-              i="23"
-              isDraggable={true}
-              isResizable={true}
-              key=".$23"
-              margin={
-                Array [
-                  10,
-                  10,
-                ]
-              }
-              maxH={Infinity}
-              maxRows={Infinity}
-              maxW={Infinity}
-              minH={1}
-              minW={1}
-              onDrag={[Function]}
-              onDragStart={[Function]}
-              onDragStop={[Function]}
-              onResize={[Function]}
-              onResizeStart={[Function]}
-              onResizeStop={[Function]}
-              rowHeight={30}
-              static={false}
-              transformScale={1}
-              useCSSTransforms={true}
-              usePercentages={false}
-              w={2}
-              x={0}
-              y={80}
-            >
-              <DraggableCore
-                allowAnyClick={false}
-                cancel=".react-resizable-handle"
-                disabled={false}
-                enableUserSelectHack={true}
-                grid={null}
-                handle=""
-                offsetParent={null}
-                onDrag={[Function]}
-                onMouseDown={[Function]}
-                onStart={[Function]}
-                onStop={[Function]}
-                scale={1}
-                transform={null}
-              >
-                <Resizable
-                  axis="both"
-                  draggableOpts={
-                    Object {
-                      "disabled": false,
+                      "disabled": true,
                     }
                   }
                   handleSize={
@@ -8495,35 +8165,37 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                   width={0}
                 >
                   <div
-                    className="react-grid-item react-draggable cssTransforms react-resizable"
-                    key="23"
+                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
+                    key="21"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
                     onTouchEnd={[Function]}
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,3200px)",
-                        "OTransform": "translate(0px,3200px)",
-                        "WebkitTransform": "translate(0px,3200px)",
+                        "MozTransform": "translate(0px,640px)",
+                        "OTransform": "translate(0px,640px)",
+                        "WebkitTransform": "translate(0px,640px)",
                         "height": "190px",
-                        "msTransform": "translate(0px,3200px)",
+                        "msTransform": "translate(0px,640px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,3200px)",
+                        "transform": "translate(0px,640px)",
                         "width": "0px",
                       }
                     }
                   >
                     <span
                       className="text"
+                      title="This item is static and cannot be removed or resized."
                     >
-                      23
+                      Static - 
+                      21
                     </span>
                     <DraggableCore
                       allowAnyClick={false}
                       cancel={null}
-                      disabled={false}
+                      disabled={true}
                       enableUserSelectHack={true}
                       grid={null}
                       handle={null}
@@ -8566,10 +8238,10 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               containerWidth={0}
               h={2}
               handle=""
-              i="24"
+              i="22"
               isDraggable={true}
               isResizable={true}
-              key=".$24"
+              key=".$22"
               margin={
                 Array [
                   10,
@@ -8594,7 +8266,7 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
               usePercentages={false}
               w={2}
               x={0}
-              y={65}
+              y={49}
             >
               <DraggableCore
                 allowAnyClick={false}
@@ -8660,6 +8332,334 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                 >
                   <div
                     className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="22"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1960px)",
+                        "OTransform": "translate(0px,1960px)",
+                        "WebkitTransform": "translate(0px,1960px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1960px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1960px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      22
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="23"
+              isDraggable={true}
+              isResizable={true}
+              key=".$23"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={66}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="23"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2640px)",
+                        "OTransform": "translate(0px,2640px)",
+                        "WebkitTransform": "translate(0px,2640px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,2640px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2640px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      23
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="24"
+              isDraggable={true}
+              isResizable={true}
+              key=".$24"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={83}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
                     key="24"
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -8667,14 +8667,14 @@ exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
                     onTouchStart={[Function]}
                     style={
                       Object {
-                        "MozTransform": "translate(0px,2600px)",
-                        "OTransform": "translate(0px,2600px)",
-                        "WebkitTransform": "translate(0px,2600px)",
-                        "height": "70px",
-                        "msTransform": "translate(0px,2600px)",
+                        "MozTransform": "translate(0px,3320px)",
+                        "OTransform": "translate(0px,3320px)",
+                        "WebkitTransform": "translate(0px,3320px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,3320px)",
                         "position": "absolute",
                         "touchAction": "none",
-                        "transform": "translate(0px,2600px)",
+                        "transform": "translate(0px,3320px)",
                         "width": "0px",
                       }
                     }

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -1,337 +1,8726 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
-<WidthProvider
+<BasicLayout
   className="layout"
   cols={12}
   items={20}
-  layout={
-    Array [
-      Object {
-        "h": 2,
-        "i": "0",
-        "w": 2,
-        "x": 0,
-        "y": 0,
-      },
-      Object {
-        "h": 3,
-        "i": "1",
-        "w": 2,
-        "x": 2,
-        "y": 0,
-      },
-      Object {
-        "h": 4,
-        "i": "2",
-        "w": 2,
-        "x": 4,
-        "y": 0,
-      },
-      Object {
-        "h": 5,
-        "i": "3",
-        "w": 2,
-        "x": 6,
-        "y": 0,
-      },
-      Object {
-        "h": 3,
-        "i": "4",
-        "w": 2,
-        "x": 8,
-        "y": 0,
-      },
-      Object {
-        "h": 4,
-        "i": "5",
-        "w": 2,
-        "x": 10,
-        "y": 0,
-      },
-      Object {
-        "h": 5,
-        "i": "6",
-        "w": 2,
-        "x": 0,
-        "y": 5,
-      },
-      Object {
-        "h": 5,
-        "i": "7",
-        "w": 2,
-        "x": 2,
-        "y": 5,
-      },
-      Object {
-        "h": 5,
-        "i": "8",
-        "w": 2,
-        "x": 4,
-        "y": 5,
-      },
-      Object {
-        "h": 5,
-        "i": "9",
-        "w": 2,
-        "x": 6,
-        "y": 5,
-      },
-      Object {
-        "h": 3,
-        "i": "10",
-        "w": 2,
-        "x": 8,
-        "y": 3,
-      },
-      Object {
-        "h": 2,
-        "i": "11",
-        "w": 2,
-        "x": 10,
-        "y": 2,
-      },
-      Object {
-        "h": 3,
-        "i": "12",
-        "w": 2,
-        "x": 0,
-        "y": 6,
-      },
-      Object {
-        "h": 2,
-        "i": "13",
-        "w": 2,
-        "x": 2,
-        "y": 4,
-      },
-      Object {
-        "h": 5,
-        "i": "14",
-        "w": 2,
-        "x": 4,
-        "y": 10,
-      },
-      Object {
-        "h": 5,
-        "i": "15",
-        "w": 2,
-        "x": 6,
-        "y": 10,
-      },
-      Object {
-        "h": 5,
-        "i": "16",
-        "w": 2,
-        "x": 8,
-        "y": 10,
-      },
-      Object {
-        "h": 2,
-        "i": "17",
-        "w": 2,
-        "x": 10,
-        "y": 4,
-      },
-      Object {
-        "h": 5,
-        "i": "18",
-        "w": 2,
-        "x": 0,
-        "y": 15,
-      },
-      Object {
-        "h": 2,
-        "i": "19",
-        "w": 2,
-        "x": 2,
-        "y": 6,
-      },
-    ]
-  }
-  measureBeforeMount={false}
   onLayoutChange={[Function]}
   rowHeight={30}
 >
-  <div
-    key="0"
+  <WidthProvider
+    className="layout"
+    cols={12}
+    items={20}
+    layout={
+      Array [
+        Object {
+          "h": 2,
+          "i": "0",
+          "w": 2,
+          "x": 0,
+          "y": 0,
+        },
+        Object {
+          "h": 3,
+          "i": "1",
+          "w": 2,
+          "x": 2,
+          "y": 0,
+        },
+        Object {
+          "h": 4,
+          "i": "2",
+          "w": 2,
+          "x": 4,
+          "y": 0,
+        },
+        Object {
+          "h": 5,
+          "i": "3",
+          "w": 2,
+          "x": 6,
+          "y": 0,
+        },
+        Object {
+          "h": 3,
+          "i": "4",
+          "w": 2,
+          "x": 8,
+          "y": 0,
+        },
+        Object {
+          "h": 4,
+          "i": "5",
+          "w": 2,
+          "x": 10,
+          "y": 0,
+        },
+        Object {
+          "h": 5,
+          "i": "6",
+          "w": 2,
+          "x": 0,
+          "y": 5,
+        },
+        Object {
+          "h": 5,
+          "i": "7",
+          "w": 2,
+          "x": 2,
+          "y": 5,
+        },
+        Object {
+          "h": 5,
+          "i": "8",
+          "w": 2,
+          "x": 4,
+          "y": 5,
+        },
+        Object {
+          "h": 5,
+          "i": "9",
+          "w": 2,
+          "x": 6,
+          "y": 5,
+        },
+        Object {
+          "h": 3,
+          "i": "10",
+          "w": 2,
+          "x": 8,
+          "y": 3,
+        },
+        Object {
+          "h": 2,
+          "i": "11",
+          "w": 2,
+          "x": 10,
+          "y": 2,
+        },
+        Object {
+          "h": 3,
+          "i": "12",
+          "w": 2,
+          "x": 0,
+          "y": 6,
+        },
+        Object {
+          "h": 2,
+          "i": "13",
+          "w": 2,
+          "x": 2,
+          "y": 4,
+        },
+        Object {
+          "h": 5,
+          "i": "14",
+          "w": 2,
+          "x": 4,
+          "y": 10,
+        },
+        Object {
+          "h": 5,
+          "i": "15",
+          "w": 2,
+          "x": 6,
+          "y": 10,
+        },
+        Object {
+          "h": 5,
+          "i": "16",
+          "w": 2,
+          "x": 8,
+          "y": 10,
+        },
+        Object {
+          "h": 2,
+          "i": "17",
+          "w": 2,
+          "x": 10,
+          "y": 4,
+        },
+        Object {
+          "h": 5,
+          "i": "18",
+          "w": 2,
+          "x": 0,
+          "y": 15,
+        },
+        Object {
+          "h": 2,
+          "i": "19",
+          "w": 2,
+          "x": 2,
+          "y": 6,
+        },
+      ]
+    }
+    measureBeforeMount={false}
+    onLayoutChange={[Function]}
+    rowHeight={30}
   >
-    <span
-      className="text"
+    <ReactGridLayout
+      autoSize={true}
+      className="layout"
+      cols={12}
+      compactType="vertical"
+      containerPadding={null}
+      draggableCancel=""
+      draggableHandle=""
+      droppingItem={
+        Object {
+          "h": 1,
+          "i": "__dropping-elem__",
+          "w": 1,
+        }
+      }
+      isDraggable={true}
+      isDroppable={false}
+      isResizable={true}
+      items={20}
+      layout={
+        Array [
+          Object {
+            "h": 2,
+            "i": "0",
+            "w": 2,
+            "x": 0,
+            "y": 0,
+          },
+          Object {
+            "h": 3,
+            "i": "1",
+            "w": 2,
+            "x": 2,
+            "y": 0,
+          },
+          Object {
+            "h": 4,
+            "i": "2",
+            "w": 2,
+            "x": 4,
+            "y": 0,
+          },
+          Object {
+            "h": 5,
+            "i": "3",
+            "w": 2,
+            "x": 6,
+            "y": 0,
+          },
+          Object {
+            "h": 3,
+            "i": "4",
+            "w": 2,
+            "x": 8,
+            "y": 0,
+          },
+          Object {
+            "h": 4,
+            "i": "5",
+            "w": 2,
+            "x": 10,
+            "y": 0,
+          },
+          Object {
+            "h": 5,
+            "i": "6",
+            "w": 2,
+            "x": 0,
+            "y": 5,
+          },
+          Object {
+            "h": 5,
+            "i": "7",
+            "w": 2,
+            "x": 2,
+            "y": 5,
+          },
+          Object {
+            "h": 5,
+            "i": "8",
+            "w": 2,
+            "x": 4,
+            "y": 5,
+          },
+          Object {
+            "h": 5,
+            "i": "9",
+            "w": 2,
+            "x": 6,
+            "y": 5,
+          },
+          Object {
+            "h": 3,
+            "i": "10",
+            "w": 2,
+            "x": 8,
+            "y": 3,
+          },
+          Object {
+            "h": 2,
+            "i": "11",
+            "w": 2,
+            "x": 10,
+            "y": 2,
+          },
+          Object {
+            "h": 3,
+            "i": "12",
+            "w": 2,
+            "x": 0,
+            "y": 6,
+          },
+          Object {
+            "h": 2,
+            "i": "13",
+            "w": 2,
+            "x": 2,
+            "y": 4,
+          },
+          Object {
+            "h": 5,
+            "i": "14",
+            "w": 2,
+            "x": 4,
+            "y": 10,
+          },
+          Object {
+            "h": 5,
+            "i": "15",
+            "w": 2,
+            "x": 6,
+            "y": 10,
+          },
+          Object {
+            "h": 5,
+            "i": "16",
+            "w": 2,
+            "x": 8,
+            "y": 10,
+          },
+          Object {
+            "h": 2,
+            "i": "17",
+            "w": 2,
+            "x": 10,
+            "y": 4,
+          },
+          Object {
+            "h": 5,
+            "i": "18",
+            "w": 2,
+            "x": 0,
+            "y": 15,
+          },
+          Object {
+            "h": 2,
+            "i": "19",
+            "w": 2,
+            "x": 2,
+            "y": 6,
+          },
+        ]
+      }
+      margin={
+        Array [
+          10,
+          10,
+        ]
+      }
+      maxRows={Infinity}
+      onDrag={[Function]}
+      onDragStart={[Function]}
+      onDragStop={[Function]}
+      onDrop={[Function]}
+      onLayoutChange={[Function]}
+      onResize={[Function]}
+      onResizeStart={[Function]}
+      onResizeStop={[Function]}
+      preventCollision={false}
+      rowHeight={30}
+      style={Object {}}
+      transformScale={1}
+      useCSSTransforms={true}
+      verticalCompact={true}
+      width={0}
     >
-      0
-    </span>
-  </div>
-  <div
-    key="1"
-  >
-    <span
-      className="text"
-    >
-      1
-    </span>
-  </div>
-  <div
-    key="2"
-  >
-    <span
-      className="text"
-    >
+      <div
+        className="react-grid-layout layout"
+        onDragEnter={[Function]}
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
+        style={
+          Object {
+            "height": "610px",
+          }
+        }
+      >
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={2}
+          handle=""
+          i="0"
+          isDraggable={true}
+          isResizable={true}
+          key=".$0"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={0}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={70}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -20,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="0"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(10px,10px)",
+                    "OTransform": "translate(10px,10px)",
+                    "WebkitTransform": "translate(10px,10px)",
+                    "height": "70px",
+                    "msTransform": "translate(10px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(10px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  0
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={3}
+          handle=""
+          i="1"
+          isDraggable={true}
+          isResizable={true}
+          key=".$1"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={2}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={110}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -18,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="1"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(8px,10px)",
+                    "OTransform": "translate(8px,10px)",
+                    "WebkitTransform": "translate(8px,10px)",
+                    "height": "110px",
+                    "msTransform": "translate(8px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(8px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  1
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={4}
+          handle=""
+          i="2"
+          isDraggable={true}
+          isResizable={true}
+          key=".$2"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={4}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={150}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -17,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="2"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(7px,10px)",
+                    "OTransform": "translate(7px,10px)",
+                    "WebkitTransform": "translate(7px,10px)",
+                    "height": "150px",
+                    "msTransform": "translate(7px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(7px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  2
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="3"
+          isDraggable={true}
+          isResizable={true}
+          key=".$3"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={6}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -15,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="3"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(5px,10px)",
+                    "OTransform": "translate(5px,10px)",
+                    "WebkitTransform": "translate(5px,10px)",
+                    "height": "190px",
+                    "msTransform": "translate(5px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(5px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  3
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={3}
+          handle=""
+          i="4"
+          isDraggable={true}
+          isResizable={true}
+          key=".$4"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={8}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={110}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -13,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="4"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(3px,10px)",
+                    "OTransform": "translate(3px,10px)",
+                    "WebkitTransform": "translate(3px,10px)",
+                    "height": "110px",
+                    "msTransform": "translate(3px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(3px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  4
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={4}
+          handle=""
+          i="5"
+          isDraggable={true}
+          isResizable={true}
+          key=".$5"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={10}
+          y={0}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={150}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -12,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="5"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(2px,10px)",
+                    "OTransform": "translate(2px,10px)",
+                    "WebkitTransform": "translate(2px,10px)",
+                    "height": "150px",
+                    "msTransform": "translate(2px,10px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(2px,10px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  5
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="6"
+          isDraggable={true}
+          isResizable={true}
+          key=".$6"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={0}
+          y={2}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -20,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="6"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(10px,90px)",
+                    "OTransform": "translate(10px,90px)",
+                    "WebkitTransform": "translate(10px,90px)",
+                    "height": "190px",
+                    "msTransform": "translate(10px,90px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(10px,90px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  6
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="7"
+          isDraggable={true}
+          isResizable={true}
+          key=".$7"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={2}
+          y={5}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -18,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="7"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(8px,210px)",
+                    "OTransform": "translate(8px,210px)",
+                    "WebkitTransform": "translate(8px,210px)",
+                    "height": "190px",
+                    "msTransform": "translate(8px,210px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(8px,210px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  7
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="8"
+          isDraggable={true}
+          isResizable={true}
+          key=".$8"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={4}
+          y={4}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -17,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="8"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(7px,170px)",
+                    "OTransform": "translate(7px,170px)",
+                    "WebkitTransform": "translate(7px,170px)",
+                    "height": "190px",
+                    "msTransform": "translate(7px,170px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(7px,170px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  8
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="9"
+          isDraggable={true}
+          isResizable={true}
+          key=".$9"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={6}
+          y={5}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -15,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="9"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(5px,210px)",
+                    "OTransform": "translate(5px,210px)",
+                    "WebkitTransform": "translate(5px,210px)",
+                    "height": "190px",
+                    "msTransform": "translate(5px,210px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(5px,210px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  9
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={3}
+          handle=""
+          i="10"
+          isDraggable={true}
+          isResizable={true}
+          key=".$10"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={8}
+          y={3}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={110}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -13,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="10"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(3px,130px)",
+                    "OTransform": "translate(3px,130px)",
+                    "WebkitTransform": "translate(3px,130px)",
+                    "height": "110px",
+                    "msTransform": "translate(3px,130px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(3px,130px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  10
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={2}
+          handle=""
+          i="11"
+          isDraggable={true}
+          isResizable={true}
+          key=".$11"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={10}
+          y={4}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={70}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -12,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="11"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(2px,170px)",
+                    "OTransform": "translate(2px,170px)",
+                    "WebkitTransform": "translate(2px,170px)",
+                    "height": "70px",
+                    "msTransform": "translate(2px,170px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(2px,170px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  11
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={3}
+          handle=""
+          i="12"
+          isDraggable={true}
+          isResizable={true}
+          key=".$12"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={0}
+          y={7}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={110}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -20,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="12"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(10px,290px)",
+                    "OTransform": "translate(10px,290px)",
+                    "WebkitTransform": "translate(10px,290px)",
+                    "height": "110px",
+                    "msTransform": "translate(10px,290px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(10px,290px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  12
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={2}
+          handle=""
+          i="13"
+          isDraggable={true}
+          isResizable={true}
+          key=".$13"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={2}
+          y={3}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={70}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -18,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="13"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(8px,130px)",
+                    "OTransform": "translate(8px,130px)",
+                    "WebkitTransform": "translate(8px,130px)",
+                    "height": "70px",
+                    "msTransform": "translate(8px,130px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(8px,130px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  13
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="14"
+          isDraggable={true}
+          isResizable={true}
+          key=".$14"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={4}
+          y={9}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -17,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="14"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(7px,370px)",
+                    "OTransform": "translate(7px,370px)",
+                    "WebkitTransform": "translate(7px,370px)",
+                    "height": "190px",
+                    "msTransform": "translate(7px,370px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(7px,370px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  14
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="15"
+          isDraggable={true}
+          isResizable={true}
+          key=".$15"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={6}
+          y={10}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -15,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="15"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(5px,410px)",
+                    "OTransform": "translate(5px,410px)",
+                    "WebkitTransform": "translate(5px,410px)",
+                    "height": "190px",
+                    "msTransform": "translate(5px,410px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(5px,410px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  15
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="16"
+          isDraggable={true}
+          isResizable={true}
+          key=".$16"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={8}
+          y={6}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -13,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="16"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(3px,250px)",
+                    "OTransform": "translate(3px,250px)",
+                    "WebkitTransform": "translate(3px,250px)",
+                    "height": "190px",
+                    "msTransform": "translate(3px,250px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(3px,250px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  16
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={2}
+          handle=""
+          i="17"
+          isDraggable={true}
+          isResizable={true}
+          key=".$17"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={10}
+          y={6}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={70}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -12,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="17"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(2px,250px)",
+                    "OTransform": "translate(2px,250px)",
+                    "WebkitTransform": "translate(2px,250px)",
+                    "height": "70px",
+                    "msTransform": "translate(2px,250px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(2px,250px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  17
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={5}
+          handle=""
+          i="18"
+          isDraggable={true}
+          isResizable={true}
+          key=".$18"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={0}
+          y={10}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={190}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -20,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="18"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(10px,410px)",
+                    "OTransform": "translate(10px,410px)",
+                    "WebkitTransform": "translate(10px,410px)",
+                    "height": "190px",
+                    "msTransform": "translate(10px,410px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(10px,410px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  18
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+        <GridItem
+          cancel=""
+          className=""
+          cols={12}
+          containerPadding={
+            Array [
+              10,
+              10,
+            ]
+          }
+          containerWidth={0}
+          h={2}
+          handle=""
+          i="19"
+          isDraggable={true}
+          isResizable={true}
+          key=".$19"
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxH={Infinity}
+          maxRows={Infinity}
+          maxW={Infinity}
+          minH={1}
+          minW={1}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          rowHeight={30}
+          static={false}
+          transformScale={1}
+          useCSSTransforms={true}
+          usePercentages={false}
+          w={2}
+          x={2}
+          y={10}
+        >
+          <DraggableCore
+            allowAnyClick={false}
+            cancel=".react-resizable-handle"
+            disabled={false}
+            enableUserSelectHack={true}
+            grid={null}
+            handle=""
+            offsetParent={null}
+            onDrag={[Function]}
+            onMouseDown={[Function]}
+            onStart={[Function]}
+            onStop={[Function]}
+            scale={1}
+            transform={null}
+          >
+            <Resizable
+              axis="both"
+              draggableOpts={
+                Object {
+                  "disabled": false,
+                }
+              }
+              handleSize={
+                Array [
+                  20,
+                  20,
+                ]
+              }
+              height={70}
+              lockAspectRatio={false}
+              maxConstraints={
+                Array [
+                  -18,
+                  Infinity,
+                ]
+              }
+              minConstraints={
+                Array [
+                  -11,
+                  30,
+                ]
+              }
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              onTouchEnd={[Function]}
+              onTouchStart={[Function]}
+              resizeHandles={
+                Array [
+                  "se",
+                ]
+              }
+              style={
+                Object {
+                  "touchAction": "none",
+                }
+              }
+              transformScale={1}
+              width={-12}
+            >
+              <div
+                className="react-grid-item react-draggable cssTransforms react-resizable"
+                key="19"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "MozTransform": "translate(8px,410px)",
+                    "OTransform": "translate(8px,410px)",
+                    "WebkitTransform": "translate(8px,410px)",
+                    "height": "70px",
+                    "msTransform": "translate(8px,410px)",
+                    "position": "absolute",
+                    "touchAction": "none",
+                    "transform": "translate(8px,410px)",
+                    "width": "-12px",
+                  }
+                }
+              >
+                <span
+                  className="text"
+                >
+                  19
+                </span>
+                <DraggableCore
+                  allowAnyClick={false}
+                  cancel={null}
+                  disabled={false}
+                  enableUserSelectHack={true}
+                  grid={null}
+                  handle={null}
+                  key="resizableHandle-se"
+                  offsetParent={null}
+                  onDrag={[Function]}
+                  onMouseDown={[Function]}
+                  onStart={[Function]}
+                  onStop={[Function]}
+                  scale={1}
+                  transform={null}
+                >
+                  <span
+                    className="react-resizable-handle react-resizable-handle-se"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "touchAction": "none",
+                      }
+                    }
+                  />
+                </DraggableCore>
+              </div>
+            </Resizable>
+          </DraggableCore>
+        </GridItem>
+      </div>
+    </ReactGridLayout>
+  </WidthProvider>
+</BasicLayout>
+`;
+
+exports[`Lifecycle tests <ResponsiveReactGridLayout> Basic Render 1`] = `
+<ShowcaseLayout
+  className="layout"
+  cols={
+    Object {
+      "lg": 12,
+      "md": 10,
+      "sm": 6,
+      "xs": 4,
+      "xxs": 2,
+    }
+  }
+  onLayoutChange={[Function]}
+  rowHeight={30}
+>
+  <div>
+    <div>
+      Current Breakpoint: 
+      xxs
+       (
       2
-    </span>
-  </div>
-  <div
-    key="3"
-  >
-    <span
-      className="text"
+       columns)
+    </div>
+    <div>
+      Compaction type:
+       
+      Vertical
+    </div>
+    <button
+      onClick={[Function]}
     >
-      3
-    </span>
-  </div>
-  <div
-    key="4"
-  >
-    <span
-      className="text"
+      Generate New Layout
+    </button>
+    <button
+      onClick={[Function]}
     >
-      4
-    </span>
-  </div>
-  <div
-    key="5"
-  >
-    <span
-      className="text"
+      Change Compaction Type
+    </button>
+    <WidthProvider
+      className="layout"
+      cols={
+        Object {
+          "lg": 12,
+          "md": 10,
+          "sm": 6,
+          "xs": 4,
+          "xxs": 2,
+        }
+      }
+      compactType="vertical"
+      layouts={
+        Object {
+          "lg": Array [
+            Object {
+              "h": 3,
+              "i": "0",
+              "static": false,
+              "w": 2,
+              "x": 1,
+              "y": 0,
+            },
+            Object {
+              "h": 3,
+              "i": "1",
+              "static": false,
+              "w": 2,
+              "x": 7,
+              "y": 0,
+            },
+            Object {
+              "h": 4,
+              "i": "2",
+              "static": false,
+              "w": 2,
+              "x": 9,
+              "y": 0,
+            },
+            Object {
+              "h": 2,
+              "i": "3",
+              "static": false,
+              "w": 2,
+              "x": 6,
+              "y": 0,
+            },
+            Object {
+              "h": 4,
+              "i": "4",
+              "static": true,
+              "w": 2,
+              "x": 5,
+              "y": 0,
+            },
+            Object {
+              "h": 2,
+              "i": "5",
+              "static": false,
+              "w": 2,
+              "x": 8,
+              "y": 0,
+            },
+            Object {
+              "h": 5,
+              "i": "6",
+              "static": false,
+              "w": 2,
+              "x": 3,
+              "y": 5,
+            },
+            Object {
+              "h": 4,
+              "i": "7",
+              "static": false,
+              "w": 2,
+              "x": 7,
+              "y": 4,
+            },
+            Object {
+              "h": 2,
+              "i": "8",
+              "static": false,
+              "w": 2,
+              "x": 10,
+              "y": 2,
+            },
+            Object {
+              "h": 2,
+              "i": "9",
+              "static": false,
+              "w": 2,
+              "x": 10,
+              "y": 2,
+            },
+            Object {
+              "h": 4,
+              "i": "10",
+              "static": false,
+              "w": 2,
+              "x": 5,
+              "y": 4,
+            },
+            Object {
+              "h": 4,
+              "i": "11",
+              "static": false,
+              "w": 2,
+              "x": 8,
+              "y": 4,
+            },
+            Object {
+              "h": 3,
+              "i": "12",
+              "static": false,
+              "w": 2,
+              "x": 5,
+              "y": 6,
+            },
+            Object {
+              "h": 3,
+              "i": "13",
+              "static": false,
+              "w": 2,
+              "x": 9,
+              "y": 6,
+            },
+            Object {
+              "h": 3,
+              "i": "14",
+              "static": false,
+              "w": 2,
+              "x": 10,
+              "y": 6,
+            },
+            Object {
+              "h": 2,
+              "i": "15",
+              "static": false,
+              "w": 2,
+              "x": 2,
+              "y": 4,
+            },
+            Object {
+              "h": 4,
+              "i": "16",
+              "static": false,
+              "w": 2,
+              "x": 5,
+              "y": 8,
+            },
+            Object {
+              "h": 3,
+              "i": "17",
+              "static": false,
+              "w": 2,
+              "x": 3,
+              "y": 6,
+            },
+            Object {
+              "h": 5,
+              "i": "18",
+              "static": false,
+              "w": 2,
+              "x": 9,
+              "y": 15,
+            },
+            Object {
+              "h": 4,
+              "i": "19",
+              "static": true,
+              "w": 2,
+              "x": 10,
+              "y": 12,
+            },
+            Object {
+              "h": 2,
+              "i": "20",
+              "static": false,
+              "w": 2,
+              "x": 10,
+              "y": 6,
+            },
+            Object {
+              "h": 4,
+              "i": "21",
+              "static": false,
+              "w": 2,
+              "x": 1,
+              "y": 12,
+            },
+            Object {
+              "h": 4,
+              "i": "22",
+              "static": false,
+              "w": 2,
+              "x": 10,
+              "y": 12,
+            },
+            Object {
+              "h": 5,
+              "i": "23",
+              "static": false,
+              "w": 2,
+              "x": 6,
+              "y": 15,
+            },
+            Object {
+              "h": 2,
+              "i": "24",
+              "static": false,
+              "w": 2,
+              "x": 3,
+              "y": 8,
+            },
+          ],
+        }
+      }
+      measureBeforeMount={false}
+      onBreakpointChange={[Function]}
+      onDrop={[Function]}
+      onLayoutChange={[Function]}
+      preventCollision={false}
+      rowHeight={30}
+      useCSSTransforms={true}
     >
-      5
-    </span>
+      <ResponsiveReactGridLayout
+        breakpoints={
+          Object {
+            "lg": 1200,
+            "md": 996,
+            "sm": 768,
+            "xs": 480,
+            "xxs": 0,
+          }
+        }
+        className="layout"
+        cols={
+          Object {
+            "lg": 12,
+            "md": 10,
+            "sm": 6,
+            "xs": 4,
+            "xxs": 2,
+          }
+        }
+        compactType="vertical"
+        containerPadding={
+          Object {
+            "lg": Array [
+              0,
+              0,
+            ],
+            "md": Array [
+              0,
+              0,
+            ],
+            "sm": Array [
+              0,
+              0,
+            ],
+            "xs": Array [
+              0,
+              0,
+            ],
+            "xxs": Array [
+              0,
+              0,
+            ],
+          }
+        }
+        layouts={
+          Object {
+            "lg": Array [
+              Object {
+                "h": 3,
+                "i": "0",
+                "static": false,
+                "w": 2,
+                "x": 1,
+                "y": 0,
+              },
+              Object {
+                "h": 3,
+                "i": "1",
+                "static": false,
+                "w": 2,
+                "x": 7,
+                "y": 0,
+              },
+              Object {
+                "h": 4,
+                "i": "2",
+                "static": false,
+                "w": 2,
+                "x": 9,
+                "y": 0,
+              },
+              Object {
+                "h": 2,
+                "i": "3",
+                "static": false,
+                "w": 2,
+                "x": 6,
+                "y": 0,
+              },
+              Object {
+                "h": 4,
+                "i": "4",
+                "static": true,
+                "w": 2,
+                "x": 5,
+                "y": 0,
+              },
+              Object {
+                "h": 2,
+                "i": "5",
+                "static": false,
+                "w": 2,
+                "x": 8,
+                "y": 0,
+              },
+              Object {
+                "h": 5,
+                "i": "6",
+                "static": false,
+                "w": 2,
+                "x": 3,
+                "y": 5,
+              },
+              Object {
+                "h": 4,
+                "i": "7",
+                "static": false,
+                "w": 2,
+                "x": 7,
+                "y": 4,
+              },
+              Object {
+                "h": 2,
+                "i": "8",
+                "static": false,
+                "w": 2,
+                "x": 10,
+                "y": 2,
+              },
+              Object {
+                "h": 2,
+                "i": "9",
+                "static": false,
+                "w": 2,
+                "x": 10,
+                "y": 2,
+              },
+              Object {
+                "h": 4,
+                "i": "10",
+                "static": false,
+                "w": 2,
+                "x": 5,
+                "y": 4,
+              },
+              Object {
+                "h": 4,
+                "i": "11",
+                "static": false,
+                "w": 2,
+                "x": 8,
+                "y": 4,
+              },
+              Object {
+                "h": 3,
+                "i": "12",
+                "static": false,
+                "w": 2,
+                "x": 5,
+                "y": 6,
+              },
+              Object {
+                "h": 3,
+                "i": "13",
+                "static": false,
+                "w": 2,
+                "x": 9,
+                "y": 6,
+              },
+              Object {
+                "h": 3,
+                "i": "14",
+                "static": false,
+                "w": 2,
+                "x": 10,
+                "y": 6,
+              },
+              Object {
+                "h": 2,
+                "i": "15",
+                "static": false,
+                "w": 2,
+                "x": 2,
+                "y": 4,
+              },
+              Object {
+                "h": 4,
+                "i": "16",
+                "static": false,
+                "w": 2,
+                "x": 5,
+                "y": 8,
+              },
+              Object {
+                "h": 3,
+                "i": "17",
+                "static": false,
+                "w": 2,
+                "x": 3,
+                "y": 6,
+              },
+              Object {
+                "h": 5,
+                "i": "18",
+                "static": false,
+                "w": 2,
+                "x": 9,
+                "y": 15,
+              },
+              Object {
+                "h": 4,
+                "i": "19",
+                "static": true,
+                "w": 2,
+                "x": 10,
+                "y": 12,
+              },
+              Object {
+                "h": 2,
+                "i": "20",
+                "static": false,
+                "w": 2,
+                "x": 10,
+                "y": 6,
+              },
+              Object {
+                "h": 4,
+                "i": "21",
+                "static": false,
+                "w": 2,
+                "x": 1,
+                "y": 12,
+              },
+              Object {
+                "h": 4,
+                "i": "22",
+                "static": false,
+                "w": 2,
+                "x": 10,
+                "y": 12,
+              },
+              Object {
+                "h": 5,
+                "i": "23",
+                "static": false,
+                "w": 2,
+                "x": 6,
+                "y": 15,
+              },
+              Object {
+                "h": 2,
+                "i": "24",
+                "static": false,
+                "w": 2,
+                "x": 3,
+                "y": 8,
+              },
+            ],
+          }
+        }
+        margin={
+          Array [
+            10,
+            10,
+          ]
+        }
+        onBreakpointChange={[Function]}
+        onDrop={[Function]}
+        onLayoutChange={[Function]}
+        onWidthChange={[Function]}
+        preventCollision={false}
+        rowHeight={30}
+        useCSSTransforms={true}
+        width={0}
+      >
+        <ReactGridLayout
+          autoSize={true}
+          className="layout"
+          cols={2}
+          compactType="vertical"
+          containerPadding={
+            Array [
+              0,
+              0,
+            ]
+          }
+          draggableCancel=""
+          draggableHandle=""
+          droppingItem={
+            Object {
+              "h": 1,
+              "i": "__dropping-elem__",
+              "w": 1,
+            }
+          }
+          isDraggable={true}
+          isDroppable={false}
+          isResizable={true}
+          layout={
+            Array [
+              Object {
+                "h": 3,
+                "i": "0",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 0,
+              },
+              Object {
+                "h": 3,
+                "i": "1",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 12,
+              },
+              Object {
+                "h": 4,
+                "i": "2",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 15,
+              },
+              Object {
+                "h": 2,
+                "i": "3",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 8,
+              },
+              Object {
+                "h": 4,
+                "i": "4",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": true,
+                "w": 2,
+                "x": 0,
+                "y": 4,
+              },
+              Object {
+                "h": 2,
+                "i": "5",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 10,
+              },
+              Object {
+                "h": 5,
+                "i": "6",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 42,
+              },
+              Object {
+                "h": 4,
+                "i": "7",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 38,
+              },
+              Object {
+                "h": 2,
+                "i": "8",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 24,
+              },
+              Object {
+                "h": 2,
+                "i": "9",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 26,
+              },
+              Object {
+                "h": 4,
+                "i": "10",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 30,
+              },
+              Object {
+                "h": 4,
+                "i": "11",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 34,
+              },
+              Object {
+                "h": 3,
+                "i": "12",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 53,
+              },
+              Object {
+                "h": 3,
+                "i": "13",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 47,
+              },
+              Object {
+                "h": 3,
+                "i": "14",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 50,
+              },
+              Object {
+                "h": 2,
+                "i": "15",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 28,
+              },
+              Object {
+                "h": 4,
+                "i": "16",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 61,
+              },
+              Object {
+                "h": 3,
+                "i": "17",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 58,
+              },
+              Object {
+                "h": 5,
+                "i": "18",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 75,
+              },
+              Object {
+                "h": 4,
+                "i": "19",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": true,
+                "w": 2,
+                "x": 0,
+                "y": 20,
+              },
+              Object {
+                "h": 2,
+                "i": "20",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 56,
+              },
+              Object {
+                "h": 4,
+                "i": "21",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 67,
+              },
+              Object {
+                "h": 4,
+                "i": "22",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 71,
+              },
+              Object {
+                "h": 5,
+                "i": "23",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 80,
+              },
+              Object {
+                "h": 2,
+                "i": "24",
+                "isDraggable": undefined,
+                "isResizable": undefined,
+                "maxH": undefined,
+                "maxW": undefined,
+                "minH": undefined,
+                "minW": undefined,
+                "moved": false,
+                "static": false,
+                "w": 2,
+                "x": 0,
+                "y": 65,
+              },
+            ]
+          }
+          margin={
+            Array [
+              10,
+              10,
+            ]
+          }
+          maxRows={Infinity}
+          onDrag={[Function]}
+          onDragStart={[Function]}
+          onDragStop={[Function]}
+          onDrop={[Function]}
+          onLayoutChange={[Function]}
+          onResize={[Function]}
+          onResizeStart={[Function]}
+          onResizeStop={[Function]}
+          preventCollision={false}
+          rowHeight={30}
+          style={Object {}}
+          transformScale={1}
+          useCSSTransforms={true}
+          verticalCompact={true}
+          width={0}
+        >
+          <div
+            className="react-grid-layout layout"
+            onDragEnter={[Function]}
+            onDragLeave={[Function]}
+            onDragOver={[Function]}
+            onDrop={[Function]}
+            style={
+              Object {
+                "height": "3390px",
+              }
+            }
+          >
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="0"
+              isDraggable={true}
+              isResizable={true}
+              key=".$0"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={0}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="0"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,0px)",
+                        "OTransform": "translate(0px,0px)",
+                        "WebkitTransform": "translate(0px,0px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,0px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,0px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      0
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="1"
+              isDraggable={true}
+              isResizable={true}
+              key=".$1"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={12}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="1"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,480px)",
+                        "OTransform": "translate(0px,480px)",
+                        "WebkitTransform": "translate(0px,480px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,480px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,480px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      1
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="2"
+              isDraggable={true}
+              isResizable={true}
+              key=".$2"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={15}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="2"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,600px)",
+                        "OTransform": "translate(0px,600px)",
+                        "WebkitTransform": "translate(0px,600px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,600px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,600px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      2
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="3"
+              isDraggable={true}
+              isResizable={true}
+              key=".$3"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={8}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="3"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,320px)",
+                        "OTransform": "translate(0px,320px)",
+                        "WebkitTransform": "translate(0px,320px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,320px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,320px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      3
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="4"
+              isDraggable={false}
+              isResizable={false}
+              key=".$4"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={true}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={4}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={true}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  className="react-resizable-hide"
+                  draggableOpts={
+                    Object {
+                      "disabled": true,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
+                    key="4"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,160px)",
+                        "OTransform": "translate(0px,160px)",
+                        "WebkitTransform": "translate(0px,160px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,160px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,160px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                      title="This item is static and cannot be removed or resized."
+                    >
+                      Static - 
+                      4
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={true}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="5"
+              isDraggable={true}
+              isResizable={true}
+              key=".$5"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={10}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="5"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,400px)",
+                        "OTransform": "translate(0px,400px)",
+                        "WebkitTransform": "translate(0px,400px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,400px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,400px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      5
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={5}
+              handle=""
+              i="6"
+              isDraggable={true}
+              isResizable={true}
+              key=".$6"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={42}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={190}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="6"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1680px)",
+                        "OTransform": "translate(0px,1680px)",
+                        "WebkitTransform": "translate(0px,1680px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,1680px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1680px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      6
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="7"
+              isDraggable={true}
+              isResizable={true}
+              key=".$7"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={38}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="7"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1520px)",
+                        "OTransform": "translate(0px,1520px)",
+                        "WebkitTransform": "translate(0px,1520px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,1520px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1520px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      7
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="8"
+              isDraggable={true}
+              isResizable={true}
+              key=".$8"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={24}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="8"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,960px)",
+                        "OTransform": "translate(0px,960px)",
+                        "WebkitTransform": "translate(0px,960px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,960px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,960px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      8
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="9"
+              isDraggable={true}
+              isResizable={true}
+              key=".$9"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={26}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="9"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1040px)",
+                        "OTransform": "translate(0px,1040px)",
+                        "WebkitTransform": "translate(0px,1040px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1040px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1040px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      9
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="10"
+              isDraggable={true}
+              isResizable={true}
+              key=".$10"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={30}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="10"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1200px)",
+                        "OTransform": "translate(0px,1200px)",
+                        "WebkitTransform": "translate(0px,1200px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,1200px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1200px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      10
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="11"
+              isDraggable={true}
+              isResizable={true}
+              key=".$11"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={34}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="11"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1360px)",
+                        "OTransform": "translate(0px,1360px)",
+                        "WebkitTransform": "translate(0px,1360px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,1360px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1360px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      11
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="12"
+              isDraggable={true}
+              isResizable={true}
+              key=".$12"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={53}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="12"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2120px)",
+                        "OTransform": "translate(0px,2120px)",
+                        "WebkitTransform": "translate(0px,2120px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,2120px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2120px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      12
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="13"
+              isDraggable={true}
+              isResizable={true}
+              key=".$13"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={47}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="13"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1880px)",
+                        "OTransform": "translate(0px,1880px)",
+                        "WebkitTransform": "translate(0px,1880px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,1880px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1880px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      13
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="14"
+              isDraggable={true}
+              isResizable={true}
+              key=".$14"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={50}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="14"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2000px)",
+                        "OTransform": "translate(0px,2000px)",
+                        "WebkitTransform": "translate(0px,2000px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,2000px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2000px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      14
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="15"
+              isDraggable={true}
+              isResizable={true}
+              key=".$15"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={28}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="15"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,1120px)",
+                        "OTransform": "translate(0px,1120px)",
+                        "WebkitTransform": "translate(0px,1120px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,1120px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,1120px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      15
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="16"
+              isDraggable={true}
+              isResizable={true}
+              key=".$16"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={61}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="16"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2440px)",
+                        "OTransform": "translate(0px,2440px)",
+                        "WebkitTransform": "translate(0px,2440px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,2440px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2440px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      16
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={3}
+              handle=""
+              i="17"
+              isDraggable={true}
+              isResizable={true}
+              key=".$17"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={58}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={110}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="17"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2320px)",
+                        "OTransform": "translate(0px,2320px)",
+                        "WebkitTransform": "translate(0px,2320px)",
+                        "height": "110px",
+                        "msTransform": "translate(0px,2320px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2320px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      17
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={5}
+              handle=""
+              i="18"
+              isDraggable={true}
+              isResizable={true}
+              key=".$18"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={75}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={190}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="18"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,3000px)",
+                        "OTransform": "translate(0px,3000px)",
+                        "WebkitTransform": "translate(0px,3000px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,3000px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,3000px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      18
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="19"
+              isDraggable={false}
+              isResizable={false}
+              key=".$19"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={true}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={20}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={true}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  className="react-resizable-hide"
+                  draggableOpts={
+                    Object {
+                      "disabled": true,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item static static cssTransforms react-resizable-hide react-resizable"
+                    key="19"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,800px)",
+                        "OTransform": "translate(0px,800px)",
+                        "WebkitTransform": "translate(0px,800px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,800px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,800px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                      title="This item is static and cannot be removed or resized."
+                    >
+                      Static - 
+                      19
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={true}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="20"
+              isDraggable={true}
+              isResizable={true}
+              key=".$20"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={56}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="20"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2240px)",
+                        "OTransform": "translate(0px,2240px)",
+                        "WebkitTransform": "translate(0px,2240px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,2240px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2240px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      20
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="21"
+              isDraggable={true}
+              isResizable={true}
+              key=".$21"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={67}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="21"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2680px)",
+                        "OTransform": "translate(0px,2680px)",
+                        "WebkitTransform": "translate(0px,2680px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,2680px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2680px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      21
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={4}
+              handle=""
+              i="22"
+              isDraggable={true}
+              isResizable={true}
+              key=".$22"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={71}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={150}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="22"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2840px)",
+                        "OTransform": "translate(0px,2840px)",
+                        "WebkitTransform": "translate(0px,2840px)",
+                        "height": "150px",
+                        "msTransform": "translate(0px,2840px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2840px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      22
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={5}
+              handle=""
+              i="23"
+              isDraggable={true}
+              isResizable={true}
+              key=".$23"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={80}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={190}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="23"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,3200px)",
+                        "OTransform": "translate(0px,3200px)",
+                        "WebkitTransform": "translate(0px,3200px)",
+                        "height": "190px",
+                        "msTransform": "translate(0px,3200px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,3200px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      23
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+            <GridItem
+              cancel=""
+              className=""
+              cols={2}
+              containerPadding={
+                Array [
+                  0,
+                  0,
+                ]
+              }
+              containerWidth={0}
+              h={2}
+              handle=""
+              i="24"
+              isDraggable={true}
+              isResizable={true}
+              key=".$24"
+              margin={
+                Array [
+                  10,
+                  10,
+                ]
+              }
+              maxH={Infinity}
+              maxRows={Infinity}
+              maxW={Infinity}
+              minH={1}
+              minW={1}
+              onDrag={[Function]}
+              onDragStart={[Function]}
+              onDragStop={[Function]}
+              onResize={[Function]}
+              onResizeStart={[Function]}
+              onResizeStop={[Function]}
+              rowHeight={30}
+              static={false}
+              transformScale={1}
+              useCSSTransforms={true}
+              usePercentages={false}
+              w={2}
+              x={0}
+              y={65}
+            >
+              <DraggableCore
+                allowAnyClick={false}
+                cancel=".react-resizable-handle"
+                disabled={false}
+                enableUserSelectHack={true}
+                grid={null}
+                handle=""
+                offsetParent={null}
+                onDrag={[Function]}
+                onMouseDown={[Function]}
+                onStart={[Function]}
+                onStop={[Function]}
+                scale={1}
+                transform={null}
+              >
+                <Resizable
+                  axis="both"
+                  draggableOpts={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  handleSize={
+                    Array [
+                      20,
+                      20,
+                    ]
+                  }
+                  height={70}
+                  lockAspectRatio={false}
+                  maxConstraints={
+                    Array [
+                      0,
+                      Infinity,
+                    ]
+                  }
+                  minConstraints={
+                    Array [
+                      -5,
+                      30,
+                    ]
+                  }
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onResize={[Function]}
+                  onResizeStart={[Function]}
+                  onResizeStop={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  resizeHandles={
+                    Array [
+                      "se",
+                    ]
+                  }
+                  style={
+                    Object {
+                      "touchAction": "none",
+                    }
+                  }
+                  transformScale={1}
+                  width={0}
+                >
+                  <div
+                    className="react-grid-item react-draggable cssTransforms react-resizable"
+                    key="24"
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
+                    style={
+                      Object {
+                        "MozTransform": "translate(0px,2600px)",
+                        "OTransform": "translate(0px,2600px)",
+                        "WebkitTransform": "translate(0px,2600px)",
+                        "height": "70px",
+                        "msTransform": "translate(0px,2600px)",
+                        "position": "absolute",
+                        "touchAction": "none",
+                        "transform": "translate(0px,2600px)",
+                        "width": "0px",
+                      }
+                    }
+                  >
+                    <span
+                      className="text"
+                    >
+                      24
+                    </span>
+                    <DraggableCore
+                      allowAnyClick={false}
+                      cancel={null}
+                      disabled={false}
+                      enableUserSelectHack={true}
+                      grid={null}
+                      handle={null}
+                      key="resizableHandle-se"
+                      offsetParent={null}
+                      onDrag={[Function]}
+                      onMouseDown={[Function]}
+                      onStart={[Function]}
+                      onStop={[Function]}
+                      scale={1}
+                      transform={null}
+                    >
+                      <span
+                        className="react-resizable-handle react-resizable-handle-se"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "touchAction": "none",
+                          }
+                        }
+                      />
+                    </DraggableCore>
+                  </div>
+                </Resizable>
+              </DraggableCore>
+            </GridItem>
+          </div>
+        </ReactGridLayout>
+      </ResponsiveReactGridLayout>
+    </WidthProvider>
   </div>
-  <div
-    key="6"
-  >
-    <span
-      className="text"
-    >
-      6
-    </span>
-  </div>
-  <div
-    key="7"
-  >
-    <span
-      className="text"
-    >
-      7
-    </span>
-  </div>
-  <div
-    key="8"
-  >
-    <span
-      className="text"
-    >
-      8
-    </span>
-  </div>
-  <div
-    key="9"
-  >
-    <span
-      className="text"
-    >
-      9
-    </span>
-  </div>
-  <div
-    key="10"
-  >
-    <span
-      className="text"
-    >
-      10
-    </span>
-  </div>
-  <div
-    key="11"
-  >
-    <span
-      className="text"
-    >
-      11
-    </span>
-  </div>
-  <div
-    key="12"
-  >
-    <span
-      className="text"
-    >
-      12
-    </span>
-  </div>
-  <div
-    key="13"
-  >
-    <span
-      className="text"
-    >
-      13
-    </span>
-  </div>
-  <div
-    key="14"
-  >
-    <span
-      className="text"
-    >
-      14
-    </span>
-  </div>
-  <div
-    key="15"
-  >
-    <span
-      className="text"
-    >
-      15
-    </span>
-  </div>
-  <div
-    key="16"
-  >
-    <span
-      className="text"
-    >
-      16
-    </span>
-  </div>
-  <div
-    key="17"
-  >
-    <span
-      className="text"
-    >
-      17
-    </span>
-  </div>
-  <div
-    key="18"
-  >
-    <span
-      className="text"
-    >
-      18
-    </span>
-  </div>
-  <div
-    key="19"
-  >
-    <span
-      className="text"
-    >
-      19
-    </span>
-  </div>
-</WidthProvider>
+</ShowcaseLayout>
 `;

--- a/test/spec/__snapshots__/lifecycle-test.js.snap
+++ b/test/spec/__snapshots__/lifecycle-test.js.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Lifecycle tests <ReactGridLayout> Basic Render 1`] = `
+<WidthProvider
+  className="layout"
+  cols={12}
+  items={20}
+  layout={
+    Array [
+      Object {
+        "h": 2,
+        "i": "0",
+        "w": 2,
+        "x": 0,
+        "y": 0,
+      },
+      Object {
+        "h": 3,
+        "i": "1",
+        "w": 2,
+        "x": 2,
+        "y": 0,
+      },
+      Object {
+        "h": 4,
+        "i": "2",
+        "w": 2,
+        "x": 4,
+        "y": 0,
+      },
+      Object {
+        "h": 5,
+        "i": "3",
+        "w": 2,
+        "x": 6,
+        "y": 0,
+      },
+      Object {
+        "h": 3,
+        "i": "4",
+        "w": 2,
+        "x": 8,
+        "y": 0,
+      },
+      Object {
+        "h": 4,
+        "i": "5",
+        "w": 2,
+        "x": 10,
+        "y": 0,
+      },
+      Object {
+        "h": 5,
+        "i": "6",
+        "w": 2,
+        "x": 0,
+        "y": 5,
+      },
+      Object {
+        "h": 5,
+        "i": "7",
+        "w": 2,
+        "x": 2,
+        "y": 5,
+      },
+      Object {
+        "h": 5,
+        "i": "8",
+        "w": 2,
+        "x": 4,
+        "y": 5,
+      },
+      Object {
+        "h": 5,
+        "i": "9",
+        "w": 2,
+        "x": 6,
+        "y": 5,
+      },
+      Object {
+        "h": 3,
+        "i": "10",
+        "w": 2,
+        "x": 8,
+        "y": 3,
+      },
+      Object {
+        "h": 2,
+        "i": "11",
+        "w": 2,
+        "x": 10,
+        "y": 2,
+      },
+      Object {
+        "h": 3,
+        "i": "12",
+        "w": 2,
+        "x": 0,
+        "y": 6,
+      },
+      Object {
+        "h": 2,
+        "i": "13",
+        "w": 2,
+        "x": 2,
+        "y": 4,
+      },
+      Object {
+        "h": 5,
+        "i": "14",
+        "w": 2,
+        "x": 4,
+        "y": 10,
+      },
+      Object {
+        "h": 5,
+        "i": "15",
+        "w": 2,
+        "x": 6,
+        "y": 10,
+      },
+      Object {
+        "h": 5,
+        "i": "16",
+        "w": 2,
+        "x": 8,
+        "y": 10,
+      },
+      Object {
+        "h": 2,
+        "i": "17",
+        "w": 2,
+        "x": 10,
+        "y": 4,
+      },
+      Object {
+        "h": 5,
+        "i": "18",
+        "w": 2,
+        "x": 0,
+        "y": 15,
+      },
+      Object {
+        "h": 2,
+        "i": "19",
+        "w": 2,
+        "x": 2,
+        "y": 6,
+      },
+    ]
+  }
+  measureBeforeMount={false}
+  onLayoutChange={[Function]}
+  rowHeight={30}
+>
+  <div
+    key="0"
+  >
+    <span
+      className="text"
+    >
+      0
+    </span>
+  </div>
+  <div
+    key="1"
+  >
+    <span
+      className="text"
+    >
+      1
+    </span>
+  </div>
+  <div
+    key="2"
+  >
+    <span
+      className="text"
+    >
+      2
+    </span>
+  </div>
+  <div
+    key="3"
+  >
+    <span
+      className="text"
+    >
+      3
+    </span>
+  </div>
+  <div
+    key="4"
+  >
+    <span
+      className="text"
+    >
+      4
+    </span>
+  </div>
+  <div
+    key="5"
+  >
+    <span
+      className="text"
+    >
+      5
+    </span>
+  </div>
+  <div
+    key="6"
+  >
+    <span
+      className="text"
+    >
+      6
+    </span>
+  </div>
+  <div
+    key="7"
+  >
+    <span
+      className="text"
+    >
+      7
+    </span>
+  </div>
+  <div
+    key="8"
+  >
+    <span
+      className="text"
+    >
+      8
+    </span>
+  </div>
+  <div
+    key="9"
+  >
+    <span
+      className="text"
+    >
+      9
+    </span>
+  </div>
+  <div
+    key="10"
+  >
+    <span
+      className="text"
+    >
+      10
+    </span>
+  </div>
+  <div
+    key="11"
+  >
+    <span
+      className="text"
+    >
+      11
+    </span>
+  </div>
+  <div
+    key="12"
+  >
+    <span
+      className="text"
+    >
+      12
+    </span>
+  </div>
+  <div
+    key="13"
+  >
+    <span
+      className="text"
+    >
+      13
+    </span>
+  </div>
+  <div
+    key="14"
+  >
+    <span
+      className="text"
+    >
+      14
+    </span>
+  </div>
+  <div
+    key="15"
+  >
+    <span
+      className="text"
+    >
+      15
+    </span>
+  </div>
+  <div
+    key="16"
+  >
+    <span
+      className="text"
+    >
+      16
+    </span>
+  </div>
+  <div
+    key="17"
+  >
+    <span
+      className="text"
+    >
+      17
+    </span>
+  </div>
+  <div
+    key="18"
+  >
+    <span
+      className="text"
+    >
+      18
+    </span>
+  </div>
+  <div
+    key="19"
+  >
+    <span
+      className="text"
+    >
+      19
+    </span>
+  </div>
+</WidthProvider>
+`;

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -8,15 +8,22 @@ import ReactGridLayout from '../../lib/ReactGridLayout';
 import BasicLayout from '../examples/1-basic';
 import ShowcaseLayout from '../examples/0-showcase';
 import deepFreeze from '../util/deepFreeze';
-import Chance from 'chance';
 import {shallow, mount} from 'enzyme';
 
 describe('Lifecycle tests', function() {
 
   // Example layouts use randomness
+  let randIdx = 0;
   beforeAll(() => {
-    const chance = new Chance(1234);
-    jest.spyOn(global.Math, 'random').mockImplementation(() => chance.random());
+    const randArr = [0.001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.999];
+    jest.spyOn(global.Math, 'random').mockImplementation(() => {
+      randIdx = (randIdx + 1) % randArr.length;
+      return randArr[randIdx];
+    });
+  });
+
+  beforeEach(() => {
+    randIdx = 0;
   });
 
   afterAll(() => {

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -25,8 +25,15 @@ describe('Lifecycle tests', function() {
 
   describe('<ReactGridLayout>', function() {
     it('Basic Render', async function() {
-      const wrapper = shallow(<BasicLayout />);
+      const wrapper = mount(<BasicLayout />);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 
+  describe('<ResponsiveReactGridLayout>', function() {
+
+    it('Basic Render', async function() {
+      const wrapper = mount(<ShowcaseLayout />);
       expect(wrapper).toMatchSnapshot();
     });
 

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -2,8 +2,12 @@
 /* eslint-env jest */
 
 import React from 'react';
+import _ from 'lodash';
+import ResponsiveReactGridLayout from '../../lib/ResponsiveReactGridLayout';
 import ReactGridLayout from '../../lib/ReactGridLayout';
 import BasicLayout from '../examples/1-basic';
+import ShowcaseLayout from '../examples/0-showcase';
+import deepFreeze from '../util/deepFreeze';
 import Chance from 'chance';
 import {shallow, mount} from 'enzyme';
 
@@ -24,6 +28,34 @@ describe('Lifecycle tests', function() {
       const wrapper = shallow(<BasicLayout />);
 
       expect(wrapper).toMatchSnapshot();
+    });
+
+    it('Does not modify layout on movement', async function() {
+      const layouts = {
+        lg: [
+          ..._.times(3, (i) => ({
+            i: String(i),
+            x: i,
+            y: 0,
+            w: 1,
+            h: 1,
+          }))
+        ]
+      };
+      const frozenLayouts = deepFreeze(layouts, {set: true, get: false /* don't crash on unknown gets */});
+      // Render the basic Responsive layout.
+      const wrapper = mount(
+        <ResponsiveReactGridLayout layouts={frozenLayouts} width={1280} breakpoint="lg">
+          {_.times(3, (i) => <div key={i} />)}
+        </ResponsiveReactGridLayout>
+      );
+
+      // Set that layout as state and ensure it doesn't change.
+      wrapper.setState({layouts: frozenLayouts});
+      wrapper.setProps({width: 800, breakpoint: 'md'}); // will generate new layout
+      wrapper.render();
+
+      expect(frozenLayouts).not.toContain('md');
     });
   });
 });

--- a/test/spec/lifecycle-test.js
+++ b/test/spec/lifecycle-test.js
@@ -1,0 +1,29 @@
+// @flow
+/* eslint-env jest */
+
+import React from 'react';
+import ReactGridLayout from '../../lib/ReactGridLayout';
+import BasicLayout from '../examples/1-basic';
+import Chance from 'chance';
+import {shallow, mount} from 'enzyme';
+
+describe('Lifecycle tests', function() {
+
+  // Example layouts use randomness
+  beforeAll(() => {
+    const chance = new Chance(1234);
+    jest.spyOn(global.Math, 'random').mockImplementation(() => chance.random());
+  });
+
+  afterAll(() => {
+    global.Math.random.mockRestore();
+  });
+
+  describe('<ReactGridLayout>', function() {
+    it('Basic Render', async function() {
+      const wrapper = shallow(<BasicLayout />);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/test/spec/utils-test.js
+++ b/test/spec/utils-test.js
@@ -9,20 +9,13 @@ import {
   moveElement,
   sortLayoutItemsByRowCol,
   validateLayout
-} from "../../lib/utils.js";
+} from "../../lib/utils";
 import {
   calcGridColWidth,
   calcGridItemPosition
-} from "../../lib/calculateUtils.js";
+} from "../../lib/calculateUtils";
 import isEqual from "lodash.isequal";
-/*:: import type { Layout } from "../../lib/utils.js"; */
 
-/*:: declare function describe(name: string, fn: Function): void; */
-/*:: declare function it(name: string, fn: Function): void; */
-/*:: declare var expect: {
-  (any): any,
-  objectContaining(params: any): any
-}; */
 
 describe("bottom", () => {
   it("Handles an empty layout as input", () => {

--- a/test/test-hook.jsx
+++ b/test/test-hook.jsx
@@ -5,7 +5,9 @@ import "style-loader!css-loader!../examples/example-styles.css";
 typeof window !== "undefined" && (window.React = React); // for devtools
 
 export default function makeLayout(Layout) {
-  class ExampleLayout extends React.Component {
+  // Basic layout that mirrors the internals of its child layout by listening to `onLayoutChange`.
+  // It does not pass any other props to the Layout.
+  class ListeningLayout extends React.Component {
     state = { layout: [] };
 
     onLayoutChange = layout => {
@@ -40,7 +42,7 @@ export default function makeLayout(Layout) {
   function run() {
     const contentDiv = document.getElementById("content");
     const gridProps = window.gridProps || {};
-    ReactDOM.render(React.createElement(ExampleLayout, gridProps), contentDiv);
+    ReactDOM.render(React.createElement(ListeningLayout, gridProps), contentDiv);
   }
   if (!document.getElementById("content")) {
     document.addEventListener("DOMContentLoaded", run);
@@ -48,5 +50,5 @@ export default function makeLayout(Layout) {
     run();
   }
 
-  return ExampleLayout;
+  return ListeningLayout;
 }

--- a/test/util/deepFreeze.js
+++ b/test/util/deepFreeze.js
@@ -1,0 +1,35 @@
+// @flow
+
+// Deep freeze an object by using a Proxy.
+// This is better than Object.freeze() as we can create coherent error messages
+// and easily only deliver frozen subobjects when they are accessed. We can
+// even add custom logic, like warning if you access a property that doesn't exist.
+/* eslint-disable no-console */
+export default function deepFreeze<T>(inputObj: T, options: {get: boolean, set: boolean} = {get: true, set: true}): $ReadOnly<{|...T|}> {
+  // Our handler that rejects any change to the object and any nested objects inside it
+  const deepFreezer = {};
+  if (options.get) {
+    deepFreezer.get = function get<T: Object>(obj: T, prop: $Keys<T>, _receiver: Proxy<T>) {
+      // Clone w/o Proxy
+      if (prop === 'toJSON') return () => obj;
+      // If dealing with nested object, nest the proxy untill it reaches the direct property of it's parent proxy
+      if (typeof obj[prop] === 'object' && obj[prop] !== null) {
+        return new Proxy(obj[prop], deepFreezer);
+      }
+      // If prop is directly accessible, just do the default operation
+      else {
+        if (!(prop in obj) && prop !== 'length' && prop !== '__esModule' && typeof prop !== 'symbol') {
+          throw new Error(`Can not get unknown prop "${String(prop)}" on frozen object.`);
+        }
+        return obj[prop];
+      }
+    };
+  }
+  if (options.set) {
+    deepFreezer.set = function set<T>(obj: T, prop: string, _val: any, _rec: Proxy<T>): boolean {
+      throw new Error(`Can not set unknown prop "${prop}" on frozen object.`);
+    };
+  }
+  // $FlowIgnore for all useful purposes the output type is T here
+  return new Proxy(inputObj, deepFreezer);
+}

--- a/test/util/setupTests.js
+++ b/test/util/setupTests.js
@@ -1,0 +1,6 @@
+// @flow
+
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/test/util/setupTests.js
+++ b/test/util/setupTests.js
@@ -1,6 +1,16 @@
 // @flow
 
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });
+
+// We rely on sort() being deterministic for tests, but it changed from QuickSort to TimSort
+// in Node 12. This breaks tests, so we monkey-patch it.
+import { sort } from "timsort";
+
+// $FlowIgnore dirty hack
+Array.prototype.sort = function(comparator) {
+  sort(this, comparator);
+  return this;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,10 @@
 var webpack = require("webpack");
 
+// Grabbed in .babelrc.js to switch on transpiling modules.
+// We want webpack to handle modules if possible.
+// This can be overridden and webpack will handle babelified CJS.
+process.env.BABEL_MODULE_TYPE = process.env.BABEL_MODULE_TYPE || 'module';
+
 // Builds bundle usable <script>. Includes RGL and all deps, excluding React.
 module.exports = {
   mode: "production",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,5 @@
-var webpack = require("webpack");
-
-// Grabbed in .babelrc.js to switch on transpiling modules.
-// We want webpack to handle modules if possible.
-// This can be overridden and webpack will handle babelified CJS.
-process.env.BABEL_MODULE_TYPE = process.env.BABEL_MODULE_TYPE || 'module';
+// @flow
+const webpack = require("webpack");
 
 // Builds bundle usable <script>. Includes RGL and all deps, excluding React.
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,22 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+airbnb-prop-types@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz#5287820043af1eb469f5b0af0d6f70da6c52aaef"
+  integrity sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==
+  dependencies:
+    array.prototype.find "^2.1.0"
+    function.prototype.name "^1.1.1"
+    has "^1.0.3"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.1.0"
+    prop-types "^15.7.2"
+    prop-types-exact "^1.2.0"
+    react-is "^16.9.0"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1551,6 +1567,11 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
+array-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
+  integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1591,6 +1612,22 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.find@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.1.1.tgz#3baca26108ca7affb08db06bf0be6cb3115a969c"
+  integrity sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.4"
+
+array.prototype.flat@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1883,6 +1920,11 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2155,10 +2197,27 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chance@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.4.tgz#d8743bf8e40bb05e024c305ca1ff441195eb23db"
+  integrity sha512-pXPDSu3knKlb6H7ahQfpq//J9mSOxYK8SMtp8MV/nRJh8aLRDIl0ipLH8At8+nVogVwtvPZzyIzY/EbcY/cLuQ==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
@@ -2318,7 +2377,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2554,6 +2613,21 @@ css-loader@^3.4.2:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -2773,6 +2847,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -2807,6 +2886,22 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
+dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -2817,12 +2912,45 @@ domain-browser@^1.1.1:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
@@ -2925,6 +3053,87 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+
+enzyme-adapter-react-16@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz#b16db2f0ea424d58a808f9df86ab6212895a4501"
+  integrity sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==
+  dependencies:
+    enzyme-adapter-utils "^1.13.0"
+    enzyme-shallow-equal "^1.0.1"
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    react-is "^16.12.0"
+    react-test-renderer "^16.0.0-0"
+    semver "^5.7.0"
+
+enzyme-adapter-utils@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.0.tgz#01c885dde2114b4690bf741f8dc94cee3060eb78"
+  integrity sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==
+  dependencies:
+    airbnb-prop-types "^2.15.0"
+    function.prototype.name "^1.1.2"
+    object.assign "^4.1.0"
+    object.fromentries "^2.0.2"
+    prop-types "^15.7.2"
+    semver "^5.7.1"
+
+enzyme-shallow-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz#7afe03db3801c9b76de8440694096412a8d9d49e"
+  integrity sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==
+  dependencies:
+    has "^1.0.3"
+    object-is "^1.0.2"
+
+enzyme-to-json@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.4.4.tgz#b30726c59091d273521b6568c859e8831e94d00e"
+  integrity sha512-50LELP/SCPJJGic5rAARvU7pgE3m1YaNj7JLM+Qkhl5t7PAs6fiyc8xzc50RnkKPFQCv0EeFVjEWdIFRGPWMsA==
+  dependencies:
+    lodash "^4.17.15"
+    react-is "^16.12.0"
+
+enzyme@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
+  integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
+  dependencies:
+    array.prototype.flat "^1.2.3"
+    cheerio "^1.0.0-rc.3"
+    enzyme-shallow-equal "^1.0.1"
+    function.prototype.name "^1.1.2"
+    has "^1.0.3"
+    html-element-map "^1.2.0"
+    is-boolean-object "^1.0.1"
+    is-callable "^1.1.5"
+    is-number-object "^1.0.4"
+    is-regex "^1.0.5"
+    is-string "^1.0.5"
+    is-subset "^0.1.1"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.7.0"
+    object-is "^1.0.2"
+    object.assign "^4.1.0"
+    object.entries "^1.1.1"
+    object.values "^1.1.1"
+    raf "^3.4.1"
+    rst-selector-parser "^2.2.3"
+    string.prototype.trim "^1.2.1"
+
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -2939,7 +3148,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -3605,10 +3814,24 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.1, function.prototype.name@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.2.tgz#5cdf79d7c05db401591dfde83e3b70c5123e9a45"
+  integrity sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    functions-have-names "^1.2.0"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+functions-have-names@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
+  integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -3911,6 +4134,13 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-element-map@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.2.0.tgz#dfbb09efe882806af63d990cf6db37993f099f22"
+  integrity sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==
+  dependencies:
+    array-filter "^1.0.0"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -3927,6 +4157,18 @@ html-escaper@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
   integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
+
+htmlparser2@^3.9.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -4243,6 +4485,11 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.1.tgz#10edc0900dd127697a92f6f9807c7617d68ac48e"
+  integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4355,6 +4602,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-number-object@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
+  integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -4441,6 +4693,11 @@ is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+  integrity sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=
 
 is-symbol@^1.0.2:
   version "1.0.3"
@@ -4946,6 +5203,14 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
+  integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
+  dependencies:
+    import-local "^2.0.0"
+    jest-cli "^24.9.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5251,7 +5516,17 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.isequal@^4.0.0:
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -5261,7 +5536,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.6.1:
+lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5538,6 +5813,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moo@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5609,6 +5889,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nearley@^2.7.10:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.1.tgz#4af4006e16645ff800e9f993c3af039857d9dbdc"
+  integrity sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -5723,6 +6014,13 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -5757,7 +6055,7 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
-object-is@^1.0.1:
+object-is@^1.0.1, object-is@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
   integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
@@ -5784,7 +6082,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.1:
+object.entries@^1.1.0, object.entries@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
   integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
@@ -6059,6 +6357,13 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -6336,6 +6641,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+prop-types-exact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
+
 prop-types@15.x, prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -6440,10 +6754,30 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
 ramda@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
   integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
@@ -6512,6 +6846,11 @@ react-hot-loader@^4.12.18:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
+react-is@^16.12.0, react-is@^16.8.6, react-is@^16.9.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -6537,6 +6876,16 @@ react-resizable@^1.9.0:
   dependencies:
     prop-types "15.x"
     react-draggable "^4.0.3"
+
+react-test-renderer@^16.0.0-0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.0.tgz#39ba3bf72cedc8210c3f81983f0bb061b14a3014"
+  integrity sha512-NQ2S9gdMUa7rgPGpKGyMcwl1d6D9MCF0lftdI3kts6kkiX+qvpC955jNjAZXlIDTjnN9jwFI8A8XhRh/9v0spA==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.0"
 
 react-transform-hmr@^1.0.2:
   version "1.0.4"
@@ -6595,7 +6944,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6:
+readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -6619,6 +6968,11 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
+  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
@@ -6878,6 +7232,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  integrity sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -6964,6 +7326,14 @@ scheduler@^0.18.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.0.tgz#a715d56302de403df742f4a9be11975b32f5698d"
+  integrity sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -6998,7 +7368,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7470,6 +7840,15 @@ string.prototype.matchall@^4.0.2:
     internal-slot "^1.0.2"
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
+
+string.prototype.trim@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
+  integrity sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
 
 string.prototype.trimleft@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,11 +2197,6 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chance@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.4.tgz#d8743bf8e40bb05e024c305ca1ff441195eb23db"
-  integrity sha512-pXPDSu3knKlb6H7ahQfpq//J9mSOxYK8SMtp8MV/nRJh8aLRDIl0ipLH8At8+nVogVwtvPZzyIzY/EbcY/cLuQ==
-
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8069,6 +8069,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+timsort@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
+  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
This PR adds a few basic enzyme tests so we can start getting actual behavioral coverage up, and start asserting on things like:

1. Should the `layout` from event callbacks like `onResize` be before or after compaction?
2. Should layouts and layoutItems passed to callbacks be clones - or should we expect userland to clone them if they don't want the values to change? There are reliability and perf repercussions here.
3. What order of operations (and final layout) should be present after a grid item collides with others? We have some basic utils tests but it'd be great to have full event emulation & snapshots.

Also relates to https://github.com/STRML/react-grid-layout/pull/1156.