### PR TITLE
Consistency: make onDrop callback more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ onResize: ItemCallback,
 // Calls when resize is complete.
 onResizeStop: ItemCallback,
 // Calls when some element has been dropped
-onDrop: (elemParams: { x: number, y: number, w: number, h: number, e: Event }) => void
+onDrop: (layout: Layout, item: ?LayoutItem, e: Event) => void
 ```
 
 ### Responsive Grid Layout Props

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -672,14 +672,14 @@ export default class ReactGridLayout extends React.Component<Props, State> {
   onDrop = (e: Event) => {
     const { droppingItem } = this.props;
     const { layout } = this.state;
-    const { x, y, w, h } = layout.find(l => l.i === droppingItem.i) || {};
+    const item = layout.find(l => l.i === droppingItem.i);
 
     // reset gragEnter counter on drop
     this.dragEnterCounter = 0;
 
     this.removeDroppingPlaceholder();
 
-    this.props.onDrop({ x, y, w, h, e });
+    this.props.onDrop(layout, item, e);
   };
 
   render() {

--- a/lib/ReactGridLayoutPropTypes.js
+++ b/lib/ReactGridLayoutPropTypes.js
@@ -38,13 +38,7 @@ export type Props = {|
   onResize: EventCallback,
   onResizeStart: EventCallback,
   onResizeStop: EventCallback,
-  onDrop: (itemPosition: {
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-    e: Event
-  }) => void,
+  onDrop: (layout: Layout, item: ?LayoutItem, e: Event) => void,
   children: ReactChildrenArray<ReactElement<any>>
 |};
 


### PR DESCRIPTION
Hello,

I need to have access to the layout on the onDrop callback. In other words, this PR doesn't solve any bug. But this callback still looks dirty compared to other callbacks, so I also try to make it more consistent with the rest of the app.

We can still improve that a bit, but I already create a PR so that we can talk about it as it is a major change to the way the callback is used.

Thanks