### PR TITLE
Add Ref to Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,10 @@ onResize: ItemCallback,
 // Calls when resize is complete.
 onResizeStop: ItemCallback,
 // Calls when some element has been dropped
-onDrop: (elemParams: { x: number, y: number, w: number, h: number, e: Event }) => void
+onDrop: (elemParams: { x: number, y: number, w: number, h: number, e: Event }) => void,
+
+// Ref for getting a reference for the wrapping div.
+innerRef: ?React.Ref
 ```
 
 ### Responsive Grid Layout Props

--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -683,7 +683,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
   };
 
   render() {
-    const { className, style, isDroppable } = this.props;
+    const { className, style, isDroppable, innerRef } = this.props;
 
     const mergedClassName = classNames(layoutClassName, className);
     const mergedStyle = {
@@ -693,6 +693,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     return (
       <div
+        ref={innerRef}
         className={mergedClassName}
         style={mergedStyle}
         onDrop={isDroppable ? this.onDrop : noop}

--- a/lib/ReactGridLayoutPropTypes.js
+++ b/lib/ReactGridLayoutPropTypes.js
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import type {
+  Ref,
   ChildrenArray as ReactChildrenArray,
   Element as ReactElement
 } from "react";
@@ -45,7 +46,8 @@ export type Props = {|
     h: number,
     e: Event
   }) => void,
-  children: ReactChildrenArray<ReactElement<any>>
+  children: ReactChildrenArray<ReactElement<any>>,
+  innerRef?: Ref<"div">
 |};
 
 export default {
@@ -175,5 +177,8 @@ export default {
       }
       keys[child.key] = true;
     });
-  }
+  },
+
+  // Optional ref for getting a reference for the wrapping div.
+  innerRef: PropTypes.any
 };


### PR DESCRIPTION
Add reference prop so we can get the internal div element. Useful for measurement and scroll control.

We could use React.forwardRef but that does a few things:
- limits version of compatible react
- breaking API change (ref would now be the div, vs the class object)

