### PR TITLE
Bump react-resizable to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash.isequal": "^4.0.0",
     "prop-types": "^15.0.0",
     "react-draggable": "^4.0.0",
-    "react-resizable": "^1.9.0"
+    "react-resizable": "^1.10.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6864,7 +6864,7 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-resizable@^1.9.0:
+react-resizable@^1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
   integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==


### PR DESCRIPTION
This PR fixes https://github.com/STRML/react-grid-layout/issues/1159