### PR TITLE
Fix fastRGLPropsEqual return function itself instead of its result.

### DIFF
--- a/lib/fastRGLPropsEqual.js
+++ b/lib/fastRGLPropsEqual.js
@@ -34,13 +34,14 @@ function getEqualType(key) {
 
 // Exports a function that compares a and b. `isEqualImpl` is a required
 // third prop, as we can't otherwise access it.
-module.exports = () =>
+module.exports = () => {
   eval(`
-  function fastRGLPropsEqual(a, b, isEqualImpl) {
-    if (a === b) return true;
-    return (
-      ${keys.map(getEqualType).join(" && ")}
-    );
-  }
-  fastRGLPropsEqual;
-`);
+    function fastRGLPropsEqual(a, b, isEqualImpl) {
+      if (a === b) return true;
+      return (
+        ${keys.map(getEqualType).join(" && ")}
+      );
+    }
+    fastRGLPropsEqual;
+  `);
+};


### PR DESCRIPTION
Fix fastRGLPropsEqual return function itself instead of the result of the function.
