### PR TITLE
config(dependency): upgrade react-draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "2.x",
     "lodash.isequal": "^4.0.0",
     "prop-types": "^15.0.0",
-    "react-draggable": "^4.0.0",
+    "react-draggable": "^4.3.1",
     "react-resizable": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
RGL is throwing an error in production mode of create-react app. likely due to uglify or tarsier optimisation. 
ref: #1186
