### PR TITLE
Clone layout array before storing to oldLayout

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -361,7 +361,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.setState({
       oldResizeItem: cloneLayoutItem(l),
-      oldLayout: this.state.layout
+      oldLayout: this.state.layout.map(layoutItem => cloneLayoutItem(layoutItem))
     });
 
     this.props.onResizeStart(layout, l, l, null, e, node);


### PR DESCRIPTION
Clone `this.state.layout` before updating `this.state.oldLayout` property.

Currently `this.state.layout` value is storing by reference to `this.state.oldLayout` as a result some incorrect behavior can happen (see the reference issue).

Reference issue - https://github.com/STRML/react-grid-layout/issues/1218
