### PR TITLE
Fix #1243

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -203,6 +203,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       this.props.children !== nextProps.children ||
       !fastRGLPropsEqual(this.props, nextProps, isEqual) ||
       this.state.activeDrag !== nextState.activeDrag ||
+      this.state.mounted !== nextState.mounted ||
       this.state.droppingPosition !== nextState.droppingPosition
     );
   }


### PR DESCRIPTION
#1243 This issue is caused by:

1. `cssTransforms` props of `GridItem` is determined by combining two things in `ReactGridLayout`: the property `cssTransforms`, and the state `mounted`.
2. The `mounted` state is initially false, causing `GridItem` using offset and percentage for positioning initially, instead of transform.
3. The `mounted` state is set to true in `componentDidMount`. But because `shouldComponentUpdate` method doesn't check it, the `GridItem` rendered won't change, until another update is triggered.

This PR fixes this issue. I've checked that it works in my application.