### PR TITLE
Fix for the incorrect drag behavior when a parent element has a trans…

### DIFF
--- a/lib/GridItem.jsx
+++ b/lib/GridItem.jsx
@@ -425,8 +425,6 @@ export default class GridItem extends React.Component<Props, State> {
   onDrag = (e: Event, { node, deltaX, deltaY }: ReactDraggableCallbackData) => {
     const { onDrag, transformScale } = this.props;
     if (!onDrag) return;
-    deltaX /= transformScale;
-    deltaY /= transformScale;
 
     if (!this.state.dragging) {
       throw new Error("onDrag called before onDragStart.");


### PR DESCRIPTION
Noticed this kind of behavior happening again: https://github.com/STRML/react-grid-layout/issues/1046
Here is also a live version: https://5wy3rz5z1x.csb.app/

Investigations led to the conclusion that both the domFns.js of react-draggable, and GridItem.js of react-grid-layout are, are scaling the deltaX and deltaY when dragging. Thus the scaling is applied twice.

I've deleted the instance that happens in the GridItem.js and now its working fine for me.

Hope this helps.
