### PR TITLE
fix: remove dist folder from npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 test/
 examples/
-dist/
 yarn.lock
 .github
 *.config.js


### PR DESCRIPTION
Today we can t use the lib throw any CDN, like unpkg.

This change is just to let people use the dist version on codepen, or any other external service.

Note it has never been published :
https://unpkg.com/browse/react-grid-layout@0.10.0/
https://unpkg.com/browse/react-grid-layout@1.0.0/
