### PR TITLE
onDragOver firefox issue

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -585,7 +585,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
     // FIXME remove this hack
     if (
       isFirefox &&
-      e.nativeEvent.target.className.indexOf(layoutClassName) === -1
+      !e.nativeEvent.target.classList.contains(layoutClassName)
     ) {
       return false;
     }


### PR DESCRIPTION
line 588: e.nativeEvent.target.className.indexOf(layoutClassName)
give "TypeError: e.nativeEvent.target.className.indexOf is not a function"

replaced by:
!e.nativeEvent.target.classList.contains(layoutClassName)
