### PR TITLE
fix: when i dragend a item, onLayoutChange trigger twice.

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -346,7 +346,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
       oldLayout: null
     });
 
-    this.onLayoutMaybeChanged(newLayout, oldLayout);
+    // this.onLayoutMaybeChanged(newLayout, oldLayout);
   }
 
   onLayoutMaybeChanged(newLayout: Layout, oldLayout: ?Layout) {


### PR DESCRIPTION
setState(layout) can trigger onLayoutMaybeChanged, so I think there should't manual call onLayoutMaybeChanged

Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
